### PR TITLE
fix: JavaScript of level 6 and higher is broken

### DIFF
--- a/static/js/syntaxModesRules.js
+++ b/static/js/syntaxModesRules.js
@@ -547,8 +547,9 @@ function rule_forRangeParen() {
 function loosenRules(rules) {
   for (const ruleSets of Object.values(rules)) {
     for (const rule of ruleSets) {
-      if (rule.regex) {
+      if (rule.regex && !rule._loosened) {
         rule.regex = rule.regex.replace(/ /g, ' +');
+        rule._loosened = true;
       }
     }
   }


### PR DESCRIPTION
For some reason, the same rule object occurs multiple times
in the rules of rules. We would then "loosen" (where "loosening"
changes the regex to accept any number of spaces where a single
space is written in the rule) the regex multiple times.

However, doing this substitution on the regex breaks the regex.

We substitute:

```javscript
' \\* '     // starting regex
// { substitute ' ' -> ' +' }
' +\\* +'   // correct regex
// { substitute ' ' -> ' +' }
' ++\\* ++' // broken regex, second '+' doesnt repeat anything
```

As a fix, make sure we don't loosen something that's already been
loosened.