### PR TITLE
Add max-height to both editor and output box.

### DIFF
--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -1,6 +1,6 @@
 <div id="editor-area" class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-5">
     <!-- Row 1: editor, output pane -->
-    <div class="flex flex-col order-1" style="min-height: 22rem">
+    <div class="flex flex-col order-1" style="min-height: 22rem; max-height: 22rem;">
       <div class="w-full flex-1 flex flex-col">
         <div id="editor"
           style="background: #272822; font-family: monospace; color: white"
@@ -64,7 +64,7 @@
         </div>
       </div>
     </div>
-    <div class="flex flex-col order-3" style="min-height: 22rem">
+    <div class="flex flex-col order-3" style="min-height: 22rem; max-height: 22rem;">
       <!-- tabindex=0 makes the div focusable -->
       <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem"></div>
       <div id="turtlecanvas" class="flex-0"></div>


### PR DESCRIPTION
- Closes #871 
- Also fixes scrolling in some corner cases (that I'm not able to replicate) where some lines on the editor are hidden on scroll even when the output box is hidden.

**How to test**:
- Go to http://localhost:5000/hedy/17?lang=en
- Run this program:
```
a is 25
while a > 0:
    print (a)
    a is a - 1
```

Notice that the output box will now be scrollable after exceeding a certain fixed height. This prevents the editor box from becoming too long.