### PR TITLE
fix: 'dict' object has no attribute 'read_aloud'

### DIFF
--- a/app.py
+++ b/app.py
@@ -273,7 +273,7 @@ def parse():
     lang = body.get('lang', requested_lang())
 
     # true if kid enabled the read aloud option
-    read_aloud = body.read_aloud
+    read_aloud = body.get('read_aloud', False)
 
     response = {}
     username = current_user(request) ['username'] or None


### PR DESCRIPTION
A tiny bug might have slipped into #927 🙃.