### PR TITLE
fix: relative paths in Tailwind build are incorrect

### DIFF
--- a/build-tools/heroku/tailwind/tailwind.config.js
+++ b/build-tools/heroku/tailwind/tailwind.config.js
@@ -6,10 +6,10 @@ module.exports = {
       // PurgeCSS will look for all things that look like css classes in these
       // files and drop all styles not referenced in any of them.
       // Put any file here that could contain HTML or CSS classes.
-      '../templates/**/*.html',
-      '../main/**/*.md',
-      '../coursedata/**/*.md',
-      '../static/js/**/*.js',
+      '../../../templates/**/*.html',
+      '../../../main/**/*.md',
+      '../../../coursedata/**/*.md',
+      '../../../static/js/**/*.js',
     ],
   },
   theme: {


### PR DESCRIPTION
This led to nearly all styles being dropped from the Tailwind
stylesheet.