### PR TITLE
Fixes #971

### DIFF
--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -118,7 +118,7 @@ Auth:
     no: "Nee"
     ok: "OK"
     cancel: "Cancel"
-    languages: "Welke programmeertaal heb je wl eens gebruikt?"
+    languages: "Welke programmeertaal heb je wel eens gebruikt?"
     other_block: "Een andere blokkentaal"
     other_text: "Een andere teksttaal"
 


### PR DESCRIPTION
Fixes a small typo in the sign-up page were the string "Welke programmeertaal heb je wel eens gebruikt?" was incorrect shown as "Welke programmeertaal heb je wl eens gebruikt?"