### PR TITLE
fix(translations): translations interface broken since YamlFile refactoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -1013,14 +1013,13 @@ def share_unshare_program(user):
 
 @app.route('/translate/<source>/<target>')
 def translate_fromto(source, target):
-    # FIXME: right now loading source file on demand. We might need to cache this...
-    source_adventures = YamlFile.for_file(f'coursedata/adventures/{source}.yaml')
-    source_levels = YamlFile.for_file(f'coursedata/level-defaults/{source}.yaml')
-    source_texts = YamlFile.for_file(f'coursedata/texts/{source}.yaml')
+    source_adventures = YamlFile.for_file(f'coursedata/adventures/{source}.yaml').to_dict()
+    source_levels = YamlFile.for_file(f'coursedata/level-defaults/{source}.yaml').to_dict()
+    source_texts = YamlFile.for_file(f'coursedata/texts/{source}.yaml').to_dict()
 
-    target_adventures = YamlFile.for_file(f'coursedata/adventures/{target}.yaml')
-    target_levels = YamlFile.for_file(f'coursedata/level-defaults/{target}.yaml')
-    target_texts = YamlFile.for_file(f'coursedata/texts/{target}.yaml')
+    target_adventures = YamlFile.for_file(f'coursedata/adventures/{target}.yaml').to_dict()
+    target_levels = YamlFile.for_file(f'coursedata/level-defaults/{target}.yaml').to_dict()
+    target_texts = YamlFile.for_file(f'coursedata/texts/{target}.yaml').to_dict()
 
     files =[]
 

--- a/website/yaml_file.py
+++ b/website/yaml_file.py
@@ -55,6 +55,17 @@ class YamlFile:
     def exists(self):
         return os.path.exists(self.filename)
 
+    def to_dict(self):
+        """Return the contents of the file as a plain dict, or an empty dict if the file doesn't exist.
+
+        You should generally not need to use this: this object can be used in places
+        where dicts are expected (except if the file doesn't exist, then accessing it will throw; we
+        can consider changing that behavior to always return an empty dict).
+        """
+        if self.exists():
+            return self.access()
+        return {}
+
     def access(self):
         """Access the data from memory.
 


### PR DESCRIPTION
The translations interface was doing an `isinstance(x, dict)` which now
fails because we are substituting the `YamlFile` instead.

Fix by adding an explicit fallback conversion to `dict`.