### PR TITLE
Fix for empty output warning when only using turtle

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -409,7 +409,7 @@ function runPythonProgram(code, hasTurtle, cb) {
   }).then(function(mod) {
     console.log('Program executed');
     // Check if the program was correct but the output window is empty: Return a warning
-    if ($('#output').is(':empty')) {
+    if ($('#output').is(':empty') && $('#turtlecanvas').is(':empty')) {
       error.showWarning(ErrorMessages.Transpile_warning, ErrorMessages.Empty_output);
     }
     if (cb) cb ();


### PR DESCRIPTION
Added a second condition to the empty output check to account for turtle canvas. Fixes #1011.
Verify by running the code, provided by the related issue, on level 7:

```
hoeken is ask 'Hoeveel hoeken krijgt dit figuur?'
hoek is 360 / hoeken
repeat hoeken times
    turn hoek
    forward 100
```