### PR TITLE
chore: re-enable all tailwind plugins

### DIFF
--- a/build-tools/heroku/tailwind/tailwind.config.js
+++ b/build-tools/heroku/tailwind/tailwind.config.js
@@ -23,22 +23,6 @@ module.exports = {
   },
   variants: {},
   corePlugins: {
-    opacity: false,
-    // No animations
-    transitionDuration: false,
-    transitionProperty: false,
-    transitionTimingFunction: false,
-
-    // No fancy CSS transforms
-    scale: false,
-    rotate: false,
-    translate: false,
-    skew: false,
-    transformOrigin: false,
-
-    // No need for placeholder colors
-    placeholderColor: false,
-
   },
   plugins: [],
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -11,8 +11,8 @@
   </head>
   <body class="bg-gray-400">
     <noscript>Hedy requires Javascript to be enabled in your browser.</noscript>
-    <div id="modal-mask" class="hidden absolute bg-black z-50 w-full h-full opacity-75"></div>
-    <div id="modal-content" class="hidden absolute z-50 p-12 pl-16 pr-16 bg-blue-400 border-2 border-gray-400 rounded-lg text-lg text-center" style="top: 40%; left: 50%; transform: translate(-50%, -50%);">
+    <div id="modal-mask" class="hidden fixed bg-black z-50 w-full h-full opacity-75"></div>
+    <div id="modal-content" class="hidden fixed z-50 p-12 pl-16 pr-16 bg-blue-400 border-2 border-gray-400 rounded-lg text-lg text-center" style="top: 40%; left: 50%; transform: translate(-50%, -50%);">
        <div id="modal-alert" class="hidden">
           <div id="modal-alert-text" class="text-white mb-8 text-xl"></div>
           <div class="ml-auto mr-auto mt-4 flex flex-row justify-center">


### PR DESCRIPTION
Originally, I had manually disabled a number of Tailwind plugins
in the config, in an attempt to keep the size of the resulting CSS
file down.

Later on, we moved to the better solution of stripping unused CSS
classes during the build, but I had not turned the plugins back on.

The result is that we *never* emitted "opacity" classes, and so they
could not be used.

This PR re-enables everything, CSS stripping is the correct and better
solution to controlling the size of the CSS bundle.

Also in this PR: change the positioning of the modal content to `fixed`
instead of `absolute`, so you can't scroll the modal away.