### PR TITLE
Fix issue #1038 Add scrollbar to adventure

### DIFF
--- a/static/css/additional.css
+++ b/static/css/additional.css
@@ -17,5 +17,5 @@
 
 .bg-white.p-4.mb-8.shadow-md.turn-pre-into-ace {
   max-height: 20em;
-  overflow: scroll;
+  overflow: auto;
 }

--- a/templates/incl-adventure-tabs.html
+++ b/templates/incl-adventure-tabs.html
@@ -10,7 +10,7 @@
         </ul>
       </div>
       {# PANES #}
-      <div style='width: 100%; min-height: 10em;' class="bg-white p-4 mb-8 shadow-md turn-pre-into-ace">
+      <div style='width: 100%; min-height: 20em;' class="bg-white p-4 mb-8 shadow-md turn-pre-into-ace">
         <div data-tabtarget="level">
           {{intro_text|commonmark}}
         </div>


### PR DESCRIPTION
Possible fix for #1038 

Added a scrollbar to adventures with a length longer than 20em. The boxes are not "hopping" anymore between levels unless the adventure contains a short text. I could implement a minimum height too to prevent the "hopping" completely.

See a gif of the result with a minimum height, maximum height and scrollbar: 
[Preview Gif](https://im7.ezgif.com/tmp/ezgif-7-5e9813f146de.gif)