### PR TITLE
Next level button on quiz returns error

### DIFF
--- a/templates/endquiz.html
+++ b/templates/endquiz.html
@@ -12,7 +12,7 @@
     <div class="p-10 button-bar border-t-8 border-green-600">
         <div></div>
         <button class="green-btn ml-1"
-                onclick="window.location = '{{ hedy_link(level, next_assignment) }}';">Ga naar
+                onclick="window.parent.location = '{{ hedy_link(level, next_assignment) }}';">Ga naar
             level {{ level }} </button>
     </div>
 


### PR DESCRIPTION
In the current quiz implementation the "next level" button at the end of the quiz doesn't work correctly. By replacing `window.location` with `window.parent.location` the error should be solved. Can be verified by testing a quiz and after finishing pressing the "next level" button. Fixes #1008.