### PR TITLE
chore: print a hint about running npm if you forgot

### DIFF
--- a/build-tools/heroku/generate-typescript
+++ b/build-tools/heroku/generate-typescript
@@ -31,6 +31,14 @@ root=$(cd $(dirname $0)/../.. && pwd)
 
 cd $root
 
+if [[ ! -f node_modules/.bin/tsc ]]; then
+    echo "👉 You need to run the following command ONCE before running 'generate-typescript':" >&2
+    echo "" >&2
+    echo "    npm ci" >&2
+    echo "" >&2
+    exit 1
+fi
+
 if [[ "${1:-}" == "--watch" ]]; then
     echo "👀 Running TypeScript compilation in watch mode. 👀"
     echo "Leave this window open and edit (and save) .ts files to your heart's content."


### PR DESCRIPTION
Not all people read `CONTRIBUTING.md`, so remind them about the right procedure if that happens.