### PR TITLE
Extend list of reserved words

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -33,8 +33,11 @@ local_keywords_enabled = True
 # dictionary to store transpilers
 TRANSPILER_LOOKUP = {}
 
-# Python keywords need hashing when used as var names
-reserved_words = ['and', 'except', 'lambda', 'with', 'as', 'finally', 'nonlocal', 'while', 'assert', 'False', 'None', 'yield', 'break', 'for', 'not', 'class', 'from', 'or', 'continue', 'global', 'pass', 'def', 'if', 'raise', 'del', 'import', 'return', 'elif', 'in', 'True', 'else', 'is', 'try']
+# builtins taken from 3.11.0 docs: https://docs.python.org/3/library/functions.html
+PYTHON_BUILTIN_FUNCTIONS = ['abs', 'aiter', 'all', 'any', 'anext', 'ascii', 'bin', 'bool', 'breakpoint', 'bytearray', 'bytes', 'callable', 'chr', 'classmethod', 'compile', 'complex', 'delattr', 'dict', 'dir', 'divmod', 'enumerate', 'eval', 'exec', 'filter', 'float', 'format', 'frozenset', 'getattr', 'globals', 'hasattr', 'hash', 'help', 'hex', 'id', 'input', 'int', 'isinstance', 'issubclass', 'iter', 'len', 'list', 'locals', 'map', 'max', 'memoryview', 'min', 'next', 'object', 'oct', 'open', 'ord', 'pow', 'print', 'property', 'range', 'repr', 'reversed', 'round', 'set', 'setattr', 'slice', 'sorted', 'staticmethod', 'str', 'sum', 'super', 'tuple', 'type', 'vars', 'zip']
+PYTHON_KEYWORDS = ['and', 'except', 'lambda', 'with', 'as', 'finally', 'nonlocal', 'while', 'assert', 'False', 'None', 'yield', 'break', 'for', 'not', 'class', 'from', 'or', 'continue', 'global', 'pass', 'def', 'if', 'raise', 'del', 'import', 'return', 'elif', 'in', 'True', 'else', 'is', 'try', 'int']
+# Python keywords and function names need hashing when used as var names
+reserved_words = set(PYTHON_BUILTIN_FUNCTIONS + PYTHON_KEYWORDS)
 
 # Let's retrieve all keywords dynamically from the cached KEYWORDS dictionary
 indent_keywords = []


### PR DESCRIPTION
**Description**

Adds 'input' to the list of reserved words, as it's a Python method that our generated code can call.

**Fixes issues/3454**

Fixes https://github.com/Felienne/hedy/issues/3454 (I think and hope)

**How to test**

This program fails on level 11 before the change but should succeed after it:
```
input = "some string"
x = ask "question"
```

If we want, I can try to add a unit-test for this, but I'm not sure where to put it. `test_level_02.py` since the the issue can be reproduced from that level onward? (Or perhaps it's a bit overkill to test every reserved keyword? I'm flexible on the matter.)

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [x] Describes changes in the format above (present tense)
- [x] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
