### PR TITLE
[BUGFIX] Allow for printing floats from level 12

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -3,6 +3,7 @@ assign: var (_IS| _EQUALS) (atom | expression)
 assign_list: var (_IS| _EQUALS) (text_in_quotes|NUMBER) (_COMMA (text_in_quotes|NUMBER))+
 
 ?atom: NUMBER | _MINUS NUMBER | var_access | text_in_quotes //unsupported numbers are gone, we can now allow floats with NUMBER
+?print_expression: var_access_print | error_unsupported_number | NUMBER
 
 equality_check: (var_access | text_in_quotes | NUMBER) (_IS| _EQUALS) (var_access | text_in_quotes | NUMBER)
 

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -23,7 +23,7 @@ class TestsLevel12(HedyTester):
     #
     # print tests
     #
-    def test_print_float(self):
+    def test_print_float_variable(self):
         code = textwrap.dedent("""\
             pi is 3.14
             print pi""")
@@ -36,7 +36,17 @@ class TestsLevel12(HedyTester):
             max_level=17,
             expected=expected
         )
+    def test_print_float(self):
+        code = "print 3.14"
+        
+        expected = "print(f'''3.14''')"
 
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected,
+            output='3.14'
+        )
     def test_print_division_float(self):
         code = "print 3 / 2"
         expected = "print(f'''{3 / 2}''')"


### PR DESCRIPTION
**Description**

_Changes in detail_

Adds a generalize grammar rule for `print_expression`

**Fixes _issue or discussion number_**

[3516](https://github.com/hedyorg/hedy/issues/3516)

**How to test**

Open a level higher or equal than 12 and issue a `print <float>`
