### PR TITLE
[GRAMMAR] Allow empty comments

### DIFF
--- a/grammars/level1.lark
+++ b/grammars/level1.lark
@@ -40,7 +40,7 @@ empty_line: _SPACE
 
 any: /.+/ -> text
 
-COMMENT: _HASH /([^\n]+)/
+COMMENT: _HASH /([^\n]*)/
 %ignore COMMENT
 
 _EOL: "\r"?"\n"+

--- a/tests/test_level/test_level_01.py
+++ b/tests/test_level/test_level_01.py
@@ -550,6 +550,17 @@ class TestsLevel1(HedyTester):
         output = 'Hallo welkom bij Hedy!'
 
         self.single_level_tester(code=code, expected=expected, output=output)
+        
+    def test_comments_may_be_empty(self):
+        code = textwrap.dedent("""\
+            #
+            # This is a comment
+            #
+            print Привіт, Хейді!""")
+        expected = "print('Привіт, Хейді!')"
+        output = "Привіт, Хейді!"
+
+        self.single_level_tester(code=code, expected=exppected, output=output)
 
     #
     # negative tests

--- a/tests/test_level/test_level_01.py
+++ b/tests/test_level/test_level_01.py
@@ -560,7 +560,7 @@ class TestsLevel1(HedyTester):
         expected = "print('Привіт, Хейді!')"
         output = "Привіт, Хейді!"
 
-        self.single_level_tester(code=code, expected=exppected, output=output)
+        self.single_level_tester(code=code, expected=expected, output=output)
 
     #
     # negative tests


### PR DESCRIPTION
This small grammar change makes Hedy ignore also those comments that have zero length.
Such comments are allowed in Python, but yield errors in Hedy, until this patch is applied.