### PR TITLE
[FIX] "manually" copy punjabi files over

### DIFF
--- a/build-tools/heroku/on-deploy.sh
+++ b/build-tools/heroku/on-deploy.sh
@@ -30,3 +30,8 @@ echo '-----> Compiling Babel translations'
 cd ..
 cd ..
 pybabel compile -f -d translations
+
+echo '-----> Move translated Punjabi to the right folder so Babel can find it'
+cd translations
+mkdir pa_Arab_pk
+cp -r pa_PK/LC_MESSAGES pa_Arab_pk


### PR DESCRIPTION
Fixes #3593

**How to test**

Go to the site and select Punjabi: 
پنجابی (عربی, پاکستان)


Verify the labels look good and do not contain placeholders (containing underscores)