### PR TITLE
[FIX] rename get_active_and_trimmed_code() missed in #3570

### DIFF
--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -9,8 +9,8 @@
   </div>
   <div class="w-full flex items-center justify-end ltr:ml-auto rtl:mr-auto gap-2 ltr:mr-4 rtl:ml-4">
     <input id="program_name" type="text" class="border border-green-400 rounded p-2 px-3 w-1/2 h-4/5" value="{{ (loaded_program or {}).name or (_('level_title') + ' ' + level_nr)}}">
-    <input type="submit" id="save_program_button" class="green-btn cursor-pointer" value="{{_('save_code_button')}}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_trimmed_code(), false);">
-    <input type="submit" id="share_program_button" class="green-btn cursor-pointer" value="{{_('share_code_button')}}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_trimmed_code(), true);">
+    <input type="submit" id="save_program_button" class="green-btn cursor-pointer" value="{{_('save_code_button')}}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_active_and_trimmed_code(), false);">
+    <input type="submit" id="share_program_button" class="green-btn cursor-pointer" value="{{_('share_code_button')}}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_active_and_trimmed_code(), true);">
     {% if tutorial %}
         <button class="green-btn" onclick="hedyApp.startLevelTutorial('{{level_nr}}')">{{_('tutorial')}}</button>
     {% endif %}


### PR DESCRIPTION
In #3570 I forgot to rename two instances of `get_trimmed_code()` breaking the ability to save programs. Oops!