### PR TITLE
[FIX] Manually adds support for Tswana

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from website.auth import current_user, login_user_from_token_cookie, requires_lo
 from website.yaml_file import YamlFile
 from website import querylog, aws_helpers, jsonbin, translating, ab_proxying, cdn, database, achievements
 import hedy_translation
-from hedy_content import ADVENTURE_ORDER_PER_LEVEL, COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES, NON_LATIN_LANGUAGES, NON_BABEL
+from hedy_content import ADVENTURE_ORDER_PER_LEVEL, COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES, NON_LATIN_LANGUAGES
 import hedyweb
 import hedy_content
 from flask_babel import gettext, Babel
@@ -36,10 +36,6 @@ import textwrap
 import zipfile
 
 logger = logging.getLogger(__name__)
-
-# Very important: First hacky-tacky the custom locales to make sure Weblate and Babel are both happy
-CUSTOM_LOCALES = {'pa_PK': 'pa_Arab_PK'}
-utils.hack_babel_core_to_support_custom_locales(CUSTOM_LOCALES)
 
 # Todo TB: This can introduce a possible app breaking bug when switching to Python 4 -> e.g. Python 4.0.1 is invalid
 if (sys.version_info.major < 3 or sys.version_info.minor < 7):

--- a/app.py
+++ b/app.py
@@ -139,8 +139,6 @@ def load_adventures_per_level(level, keyword_lang):
 
 @babel.localeselector
 def get_locale():
-    if session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en')) in NON_BABEL:
-        return "en"
     return session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en'))
 
 

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -39,8 +39,9 @@ ALL_KEYWORD_LANGUAGES = {}
 # Todo TB -> We create this list manually, but it would be nice if we find a way to automate this as well
 NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'pa_PK', 'ru', 'zh_Hans']
 
-# It would be nice if we created this list manually but couldn't find a way to retrieve this from Babel
-NON_BABEL = ['tn']
+# Babel has a different naming convention than Weblate and doesn't support some languages -> fix this manually
+RENAMED_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK'}
+CUSTOM_BABEL_LANGUAGES = ['tn']
 
 ADVENTURE_NAMES = [
     'default',
@@ -278,21 +279,11 @@ if not os.path.isdir('translations'):
     ALL_KEYWORD_LANGUAGES['en'] = 'EN'
 
 for folder in os.listdir('translations'):
-    # we cant properly open non-supported langs like Tswana (tn)
-    # so we have to load en for those until Babel adds support
-    if folder in NON_BABEL:
-        folder = 'en'
     locale_dir = os.path.join('translations', folder, 'LC_MESSAGES')
     if not os.path.isdir(locale_dir):
         continue
-
-    if folder == 'pa_PK':  # Babel uses a different name to indicate the Arabic script
-        folder_babel = 'pa_Arab_PK'
-    else:
-        folder_babel = folder
-
     if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
-        locale = Locale.parse(folder_babel)
+        locale = Locale.parse(folder)
         languages[folder] = locale.display_name.title()
 
 for l in sorted(languages):

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -4,6 +4,7 @@ import logging
 
 from babel import Locale, languages
 
+from utils import customize_babel_locale, add_babel_locale
 from website.yaml_file import YamlFile
 import iso3166
 
@@ -42,6 +43,9 @@ NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'pa_PK', 'ru', 
 # Babel has a different naming convention than Weblate and doesn't support some languages -> fix this manually
 RENAMED_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK'}
 CUSTOM_BABEL_LANGUAGES = ['tn']
+
+customize_babel_locale(RENAMED_BABEL_LANGUAGES)
+add_babel_locale(CUSTOM_BABEL_LANGUAGES)
 
 ADVENTURE_NAMES = [
     'default',

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -286,11 +286,12 @@ for folder in os.listdir('translations'):
     if not os.path.isdir(locale_dir):
         continue
     if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
-        if language in CUSTOM_LANGUAGE_TRANSLATIONS.keys():
-            languages[folder] = CUSTOM_BABEL_LANGUAGES.get(language)
+        if folder in CUSTOM_LANGUAGE_TRANSLATIONS.keys():
+            languages[folder] = CUSTOM_LANGUAGE_TRANSLATIONS.get(folder)
             continue
         locale = Locale.parse(folder)
         languages[folder] = locale.display_name.title()
+
 
 for l in sorted(languages):
     ALL_LANGUAGES[l] = languages[l]

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -42,6 +42,8 @@ NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'pa_PK', 'ru', 
 
 # Babel has a different naming convention than Weblate and doesn't support some languages -> fix this manually
 CUSTOM_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK', 'tn': 'en'}
+# For the non-existing language manually overwrite the display language to make sure it is displayed correctly
+CUSTOM_LANGUAGE_TRANSLATIONS = {'tn': 'Setswana'}
 customize_babel_locale(CUSTOM_BABEL_LANGUAGES)
 
 ADVENTURE_NAMES = [
@@ -284,6 +286,9 @@ for folder in os.listdir('translations'):
     if not os.path.isdir(locale_dir):
         continue
     if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
+        if language in CUSTOM_LANGUAGE_TRANSLATIONS.keys():
+            languages[folder] = CUSTOM_BABEL_LANGUAGES.get(language)
+            continue
         locale = Locale.parse(folder)
         languages[folder] = locale.display_name.title()
 

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -4,7 +4,7 @@ import logging
 
 from babel import Locale, languages
 
-from utils import customize_babel_locale, add_babel_locale
+from utils import customize_babel_locale
 from website.yaml_file import YamlFile
 import iso3166
 
@@ -41,11 +41,8 @@ ALL_KEYWORD_LANGUAGES = {}
 NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'pa_PK', 'ru', 'zh_Hans']
 
 # Babel has a different naming convention than Weblate and doesn't support some languages -> fix this manually
-RENAMED_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK'}
-CUSTOM_BABEL_LANGUAGES = ['tn']
-
-customize_babel_locale(RENAMED_BABEL_LANGUAGES)
-add_babel_locale(CUSTOM_BABEL_LANGUAGES)
+CUSTOM_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK', 'tn': 'en'}
+customize_babel_locale(CUSTOM_BABEL_LANGUAGES)
 
 ADVENTURE_NAMES = [
     'default',

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -1026,7 +1026,7 @@ msgstr "Programmer's mode"
 
 #, fuzzy
 msgid "nav_start"
-msgstr "Home"
+msgstr "This is a test!"
 
 #, fuzzy
 msgid "nav_hedy"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -1026,7 +1026,7 @@ msgstr "Programmer's mode"
 
 #, fuzzy
 msgid "nav_start"
-msgstr "This is a test!"
+msgstr "Home"
 
 #, fuzzy
 msgid "nav_hedy"

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,7 @@ import uuid
 from flask_babel import gettext, format_date, format_datetime, format_timedelta
 from ruamel import yaml
 import commonmark
+
 commonmark_parser = commonmark.Parser()
 commonmark_renderer = commonmark.HtmlRenderer()
 from bs4 import BeautifulSoup
@@ -84,26 +85,30 @@ NORMAL_PREFIX_CODE = textwrap.dedent("""\
             return number
         """)
 
+
 class Timer:
-  """A quick and dirty timer."""
-  def __init__(self, name):
-    self.name = name
+    """A quick and dirty timer."""
 
-  def __enter__(self):
-    self.start = time.time()
+    def __init__(self, name):
+        self.name = name
 
-  def __exit__(self, type, value, tb):
-    delta = time.time() - self.start
-    print(f'{self.name}: {delta}s')
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, tb):
+        delta = time.time() - self.start
+        print(f'{self.name}: {delta}s')
 
 
 def timer(fn):
-  """Decoractor for fn."""
-  @functools.wraps(fn)
-  def wrapper(*args, **kwargs):
-    with Timer(fn.__name__):
-      return fn(*args, **kwargs)
-  return wrapper
+    """Decoractor for fn."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with Timer(fn.__name__):
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def timems():
@@ -115,6 +120,7 @@ def timems():
     """
     return int(round(time.time() * 1000))
 
+
 def times():
     """Return the UNIX timestamp in seconds.
 
@@ -123,9 +129,8 @@ def times():
     return int(round(time.time()))
 
 
-
-
 DEBUG_MODE = False
+
 
 def is_debug_mode():
     """Return whether or not we're in debug mode.
@@ -154,8 +159,9 @@ def dump_yaml_rt(data):
     """Dump round-tripped YAML."""
     return yaml.round_trip_dump(data, indent=4, width=999)
 
+
 def slash_join(*args):
-    ret =[]
+    ret = []
     for arg in args:
         if not arg: continue
 
@@ -163,6 +169,7 @@ def slash_join(*args):
             ret.append('/')
         ret.append(arg.lstrip('/') if ret else arg)
     return ''.join(ret)
+
 
 def is_testing_request(request):
     """Whether the current request is a test request.
@@ -174,8 +181,10 @@ def is_testing_request(request):
     """
     return not is_heroku() and bool('X-Testing' in request.headers and request.headers['X-Testing'])
 
+
 def extract_bcrypt_rounds(hash):
     return int(re.match(r'\$2b\$\d+', hash)[0].replace('$2b$', ''))
+
 
 def isoformat(timestamp):
     """Turn a timestamp into an ISO formatted string."""
@@ -207,7 +216,6 @@ def is_heroku():
 
 
 def version():
-
     # """Get the version from the Heroku environment variables."""
     if not is_heroku():
         return 'DEV'
@@ -217,6 +225,7 @@ def version():
 
     commit = os.getenv('HEROKU_SLUG_COMMIT', '????')[0:6]
     return the_date.strftime('%Y %b %d') + f'({commit})'
+
 
 def valid_email(s):
     return bool(re.match(r'^(([a-zA-Z0-9_+\.\-]+)@([\da-zA-Z\.\-]+)\.([a-zA-Z\.]{2,6})\s*)$', s))
@@ -237,7 +246,7 @@ def atomic_write_file(filename, mode='wb'):
     tmp_file = f'{filename}.{os.getpid()}'
     with open(tmp_file, mode) as f:
         yield f
-    
+
     os.replace(tmp_file, filename)
 
 
@@ -247,8 +256,10 @@ def atomic_write_file(filename, mode='wb'):
 def mstoisostring(date):
     return datetime.datetime.fromtimestamp(int(str(date)[:-3])).isoformat()
 
+
 def string_date_to_date(date):
     return datetime.datetime.strptime(date, "%Y-%m-%d")
+
 
 def timestamp_to_date(timestamp, short_format=False):
     try:
@@ -267,8 +278,10 @@ def delta_timestamp(date, short_format=False):
         delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(str(date)[:-3]))
     return format_timedelta(delta)
 
+
 def stoisostring(date):
     return datetime.datetime.fromtimestamp(date)
+
 
 def localized_date_format(date, short_format=False):
     # Improve the date by using the Flask Babel library and return timestamp as expected by language
@@ -278,13 +291,16 @@ def localized_date_format(date, short_format=False):
         timestamp = datetime.datetime.fromtimestamp(int(str(date)[:-3]))
     return format_date(timestamp, format='medium') + " " + format_datetime(timestamp, "H:mm")
 
+
 def datetotimeordate(date):
     print(date)
     return date.replace("T", " ")
 
+
 # https://stackoverflow.com/a/2257449
 def random_id_generator(size=6, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
+
 
 # This function takes a Markdown string and returns a list with each of the HTML elements obtained
 # by rendering the Markdown into HTML.
@@ -315,6 +331,7 @@ def session_id():
             session['session_id'] = uuid.uuid4().hex
     return session['session_id']
 
+
 # https://github.com/python-babel/babel/issues/454
 def customize_babel_locale(custom_locales: dict):
     from babel.core import get_global
@@ -323,16 +340,15 @@ def customize_babel_locale(custom_locales: dict):
         db[custom_name] = custom_name
     import babel.localedata
 
-    o_exists, o_load, o_parse_locale = babel.localedata.exists, babel.localedata.load, babel.core.parse_locale
+    o_exists, o_load = babel.localedata.exists, babel.localedata.load
     if o_exists.__module__ != __name__:
         def exists(name):
             name = custom_locales.get(name, name)
             return o_exists(name)
+
         def load(name, merge_inherited=True):
             name = custom_locales.get(name, name)
             return o_load(name, merge_inherited)
+
         babel.localedata.exists = exists
         babel.localedata.load = load
-
-def add_babel_locale(new_locales):
-    print(new_locales)

--- a/utils.py
+++ b/utils.py
@@ -316,45 +316,23 @@ def session_id():
     return session['session_id']
 
 # https://github.com/python-babel/babel/issues/454
-def hack_babel_core_to_support_custom_locales(custom_locales: dict):
-    """ Hack Babel core to make it support custom locale names
-
-    Based on : https://github.com/python-babel/babel/issues/454
-
-    Patch mechanism provided by @kolypto
-
-    Args:
-        custom_locales: Mapping from { custom name => ordinary name }
-    """
+def customize_babel_locale(custom_locales: dict):
     from babel.core import get_global
-
-    # In order for Babel to know "en_CUSTOM", we have to hack its database and put our custom
-    # locale names there.
-    # This database is pickle-loaded from a .dat file and cached, so we only have to do it once.
     db = get_global('likely_subtags')
     for custom_name in custom_locales:
         db[custom_name] = custom_name
-
-    # Also, monkey-patch the exists() and load() functions that load locale data from 'babel/locale-data'
     import babel.localedata
 
-    # Originals
     o_exists, o_load, o_parse_locale = babel.localedata.exists, babel.localedata.load, babel.core.parse_locale
-
-    # Make sure we do not patch twice
     if o_exists.__module__ != __name__:
-        # Definitions
         def exists(name):
-            # Convert custom names to normalized names
             name = custom_locales.get(name, name)
             return o_exists(name)
-
         def load(name, merge_inherited=True):
-            # Convert custom names to normalized names
             name = custom_locales.get(name, name)
             return o_load(name, merge_inherited)
-            # Make sure we do not patch twice
-
-        # Patch
         babel.localedata.exists = exists
         babel.localedata.load = load
+
+def add_babel_locale(new_locales):
+    print(new_locales)


### PR DESCRIPTION
**Description**
In this PR we fix the support for Tswana that is not natively supported by Babel. We use the same work-around as we used in #3599 for adding support for `pa_PK`. Simply re-direct Babel to another language when the non-supported language is called but **do not** overwrite the locale parser -> keep this to the original "unsupported" language.

**Fixes**
This PR fixes #3600.

**How to test**
Verify that Tswana is listed in the language dropdown selector. Also verify that the translations are wrapped correctly by both changing some stuff in the `tn.yaml` files in `/content` and the .po files in `/translations`. In the second case don't forget to compile the translations.
