### PR TITLE
[FIX] run all tests again, disable filters

### DIFF
--- a/tests/test_snippets/test_adventures.py
+++ b/tests/test_snippets/test_adventures.py
@@ -88,13 +88,13 @@ def collect_snippets(path, filtered_language = None):
   return Hedy_snippets
 
 # use this to filter on 1 lang, zh_Hans for Chinese, nb_NO for Norwegian, pt_PT for Portuguese
-filtered_language = 'en'
+# filtered_language = 'en'
 
 Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/adventures', filtered_language=filtered_language)]
 
-level = 4
-if level:
-    Hedy_snippets = [(name, snippet) for (name, snippet) in Hedy_snippets if snippet.level == level]
+# level = 4
+# if level:
+#     Hedy_snippets = [(name, snippet) for (name, snippet) in Hedy_snippets if snippet.level == level]
 
 Hedy_snippets = HedyTester.translate_keywords_in_snippets(Hedy_snippets)
 


### PR DESCRIPTION
#3583 accidentally commented out some tests using the filters. No problem because they do run but let's restore them!