### PR TITLE
[TESTING] Remove app.py from triggering language related tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -41,7 +41,7 @@ jobs:
       id: check_file_changed
       run: |
         $diff = git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }}
-        $SourceDiff = $diff | Where-Object { $_ -match '^content/' -or $_ -match '^grammars/' -or $_ -match '^highlighting/' -or $_ -match '^tests/' -or $_ -match '^app.py' -or $_ -match '^hedy.py'}
+        $SourceDiff = $diff | Where-Object { $_ -match '^content/' -or $_ -match '^grammars/' -or $_ -match '^highlighting/' -or $_ -match '^tests/' -or $_ -match '^hedy.py'}
         $HasDiff = $SourceDiff.Length -gt 0
         Write-Host "::set-output name=docs_changed::$HasDiff"
     - name: Run all tests


### PR DESCRIPTION
**Description**

In #3623  we accidentally allowed changes to `app.py` to trigger all tests, which shouldn't be the case. In this PR we remove it from that section of github actions.
