### PR TITLE
[CHORE] Prevent "deploy to prod" workflow from being accidentally run

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -6,6 +6,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Require one of these roles, configured ON THE REPOSITORY itself
+      # (On the Organization is not enough)
+      - if: github.actor.role != 'Maintainer' && github.actor.role != 'Admin'
+        run: |
+          echo "You must be a Maintainer or Admin to run this workflow." >&2
+          exit 1
       - uses: actions/checkout@v2
       - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
         with:


### PR DESCRIPTION
Make sure only people with sufficient permissions, *configured on the repository*, get to run the "deploy to prod" workflow.

**How to test**

After merging: run the workflow. It should work. Let me run the workflow. It should not.
