### PR TITLE
[CHORE] Fix typos in various .md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Helping build Hedy
 ------------
 
-We would be grateful if you help make Hedy better! First you will want to follow the instructions below to run the code locally and configuring your manchine as explained below. After that, you want to look at these things:
+We would be grateful if you help make Hedy better! First you will want to follow the instructions below to run the code locally and configuring your machine as explained below. After that, you want to look at these things:
 
 **Open issues**
 
@@ -19,7 +19,7 @@ We also run a Discord channel to enable users and contributors to get in touch w
 
 **Discussions**
 
-The [Discussion board](https://github.com/Felienne/hedy/discussions) has ideas that are not yet detailed enough to be put into issue, like big new features or overhuals of the language or architecture. If you are interested in picking up such a large feature do [let us know](mailto:hello@hedy.org) and read the corresponding discussion to see what has alrady been considered.
+The [Discussion board](https://github.com/Felienne/hedy/discussions) has ideas that are not yet detailed enough to be put into issue, like big new features or overhauls of the language or architecture. If you are interested in picking up such a large feature do [let us know](mailto:hello@hedy.org) and read the corresponding discussion to see what has already been considered.
 
 **For newcomers: No PR without an issue and no "issue + PR"**
 
@@ -85,13 +85,13 @@ You will see the Cypress Launchpad in which you should choose to open the End2En
 
 ### Feeding the local database
 
-Hedy uses a local database in developing enviroments. This database is called `dev_database.py` and it's not tracked by Git. To feed this local database you can use the one that's been filled with data already, `data-for-testing.json`, it contains:
+Hedy uses a local database in developing environments. This database is called `dev_database.py` and it's not tracked by Git. To feed this local database you can use the one that's been filled with data already, `data-for-testing.json`, it contains:
 
 1. Five users, from user1 to user5.
 2. One teacher called teacher1.
 3. Five students, from student1 to student5.
 4. A class called CLASS1.
-5. Several saved programs, quiz attemps and some users have achievements.
+5. Several saved programs, quiz attempt and some users have achievements.
 
 The password to all of the accounts is 123456
 
@@ -250,11 +250,11 @@ docker run -it --rm -p 8080:8080 --mount type=bind,source="$(pwd)",target=/app h
 
 ## Testing Teacher facing features locally
 
-For some things like making classes you need a teacher's account and you might want to test that locally. To do so, you have to first make an account, this works offline without issues. Then you have to run Hedy with the environment variable ADMIN_USER set to your username, f.e. ADMIN_USER=Pete. It works a bit differently in each IDE, this is whta it looks like for PyCharm:
+For some things like making classes you need a teacher's account and you might want to test that locally. To do so, you have to first make an account, this works offline without issues. Then you have to run Hedy with the environment variable ADMIN_USER set to your username, f.e. ADMIN_USER=Pete. It works a bit differently in each IDE, this is what it looks like for PyCharm:
 
 ![image](https://user-images.githubusercontent.com/1003685/152981667-0ab1f273-c668-429d-8ac4-9dd554f9bab3.png)
 
-Once you have made yourself an admin, you can acess the admin interface on http://localhost:8080/admin. Go to the Users Overview, and on the users page, select the tickmark under Teacher to make your account a teacher:
+Once you have made yourself an admin, you can access the admin interface on http://localhost:8080/admin. Go to the Users Overview, and on the users page, select the tick-mark under Teacher to make your account a teacher:
 
 ![image](https://user-images.githubusercontent.com/1003685/152981987-64010e8b-a850-4178-aa51-42b0f6cd3aeb.png)
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -26,7 +26,7 @@ Click on "Languages" in the menu on top to get to this screen:
 
 ![](image/TRANSLATING/1652368938016.png)
 
-Here you can see the progress of languages, calculated over all components. There are a few reasons why a translation is not complete. First of course, because texts are not yet translated. But on this screen you can see more reasons. Often, the 100% is nog reached because of checks that failed. This tool checks many things, like "are question marks copied to the translation". The checks make translations better. You as a translator can dismiss any of these checks per text if you're sure it does not apply.
+Here you can see the progress of languages, calculated over all components. There are a few reasons why a translation is not complete. First of course, because texts are not yet translated. But on this screen you can see more reasons. Often, the 100% is not reached because of checks that failed. This tool checks many things, like "are question marks copied to the translation". The checks make translations better. You as a translator can dismiss any of these checks per text if you're sure it does not apply.
 
 Now click on Dutch to reach the following screen:
 
@@ -42,7 +42,7 @@ Click on Adventures to reach this screen:
 
 Now you see an overview of this component. Little too much information maybe. Don't worry, just start with "Strings marked for edit". These are strings that have the English text in place of the translation or have been translated, but the source has changed. All texts start with the English source text, this way every text that has not been translated yet, is at least visible in English on the website.
 
-If you're a little more expericend, you might want to try some of the texts that have specific checks failing.
+If you're a little more experienced, you might want to try some of the texts that have specific checks failing.
 At the right, you can choose between Translate or Zen.
 
 If you choose for Translate for the Failing checks: Placeholders, you might see something like this:
@@ -53,9 +53,9 @@ Again, maybe a little too much information, but a lot is very helpful. Browse a 
 
 ![](image/TRANSLATING/1652370483598.png)
 
-You see more strings on the same page for faster translation, but less helpfull info per translation.
+You see more strings on the same page for faster translation, but less helpful info per translation.
 
-One important thing to notice is the **grayed pieces of text**. This is computer code and should not be translated! There are two versions: keywords between {}, this is in real code that we need to be able to run. Translating these wil make our software fail. The other version is also between {}, but with extra `` around them. This is to highlight this code within text. It wil not make our software fail, but will make the program harder to use. So both of these should be handled with care.
+One important thing to notice is the **grayed pieces of text**. This is computer code and should not be translated! There are two versions: keywords between {}, this is in real code that we need to be able to run. Translating these will make our software fail. The other version is also between {}, but with extra `` around them. This is to highlight this code within text. It wil not make our software fail, but will make the program harder to use. So both of these should be handled with care.
 
 
 

--- a/WEBLATE.md
+++ b/WEBLATE.md
@@ -1,16 +1,16 @@
 # Fixing Weblate Merge conflicts
 
-If there are too many changes, Weblate might not be able to resolve them automatically. You will then have to fix stuff locally, to do so, follow these stetps:
+If there are too many changes, Weblate might not be able to resolve them automatically. You will then have to fix stuff locally, to do so, follow these steps:
 
-**Gather the commits from weblate by adding an extra remote to your local repo**
+**Gather the commits from Weblate by adding an extra remote to your local repo**
 
 `git remote add weblate https://hosted.weblate.org/git/hedy/adventures/`
 
-This enables us to contact the weblate repo.
+This enables us to contact the Weblate repo.
 
 **Now grab the Weblate commits**
 
-With `git fetch weblate` you get all commits that exist in weblate.
+With `git fetch weblate` you get all commits that exist in Weblate.
 
 **Make a new branch**
 
@@ -18,7 +18,7 @@ Switch to a fresh branch with `git checkout -b newbranchname`
 
 **Merge Weblate commits in**
 
-Now with `git merge weblate/main` you can merge the Weblate commits into the current branch. This can lead to merge conflicts (in fact, it will, cause why otherwise would you be going trough all this trouble?) that you will have to manually fix.
+Now with `git merge weblate/main` you can merge the Weblate commits into the current branch. This can lead to merge conflicts (in fact, it will, cause why otherwise would you be going through all this trouble?) that you will have to manually fix.
 
 **Push the fixed branch**
 
@@ -36,11 +36,11 @@ For `messages.pot`:
 
 # New strings versus fuzzy strings
 
-There are a few Weblate peculiarities that are handy to know in working with the strings. If you add a new string in the code base in English, it will be automatially copied to ll languages in English, and then shown in English in the UI. However if you _update_ a string, the original (even if it is still the original, untranslated English one) will remain as is in Weblate, and will just be shown as #fuzzy (which is not visible to users of the Hedy site)
+There are a few Weblate peculiarities that are handy to know in working with the strings. If you add a new string in the code base in English, it will be automatically copied to ll languages in English, and then shown in English in the UI. However if you _update_ a string, the original (even if it is still the original, untranslated English one) will remain as is in Weblate, and will just be shown as #fuzzy (which is not visible to users of the Hedy site)
 
 # Working with Weblate locally
 
-Installing wlc (pip install wlc) gives you some control over the Weblate environment. To use this, create a .weblate file in the root and put the following content in there:
+Installing wlc (`pip install wlc`) gives you some control over the Weblate environment. To use this, create a .weblate file in the root and put the following content in there:
 
 ```
 [weblate]


### PR DESCRIPTION
**Description**

Fix various typos in markdown files.
Since I wasn't sure if the document should be in British English or American English, I opted to retain those words as it is.

I see that in the `CONTRIBUTING.md` that first PR's should ideally be targeting open issues, but I don't seem to see any issues surrounding this, and this seems reasonable enough of a pull request.

Used a built-in dictionary on Linux, so may have false positive/false negatives.

**How to test**

No functional code changes, so no testing needed

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [ ] Links to an existing issue or discussion 
- [x] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
