### PR TITLE
[TESTING] Only test snippets when PR comes from Weblate

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,7 +48,7 @@ jobs:
       shell: pwsh
       id: weblate_tests
       if: ${{ github.event.pull_request.user.login == 'weblate' }}
-      run: |F
+      run: |
         Write-Host "::set-output name=run::True"
         build-tools/github/validate --weblate
     - name: Run all tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -46,16 +46,18 @@ jobs:
         Write-Host "::set-output name=docs_changed::$HasDiff"
     - name: Run weblate tests
       shell: pwsh
+      id: weblate_tests
+      if: ${{ github.event.pull_request.user.login == 'weblate' }}
       run: |
+        Write-Host "::set-output name=run::True"
         build-tools/github/validate --weblate
-        exit 1
     - name: Run all tests
       shell: pwsh
-      if: steps.check_file_changed.outputs.docs_changed == 'True' -or ${{ github.event.label.name == 'force_tests' }}
+      if: steps.check_file_changed.outputs.docs_changed == 'True' -or ${{ github.event.label.name == 'force_tests' }} -and steps.check_file_changed.weblate_tests.run != 'True'
       run: |
         build-tools/github/validate --all
     - name: Run non-code related tests
       shell: pwsh
-      if: steps.check_file_changed.outputs.docs_changed != 'True'
+      if: steps.check_file_changed.outputs.docs_changed != 'True' -and steps.check_file_changed.weblate_tests.run != 'True'
       run: |
         build-tools/github/validate

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,16 +48,16 @@ jobs:
       shell: pwsh
       id: weblate_tests
       if: ${{ github.event.pull_request.user.login == 'weblate' }}
-      run: |
+      run: |F
         Write-Host "::set-output name=run::True"
         build-tools/github/validate --weblate
     - name: Run all tests
       shell: pwsh
-      if: steps.check_file_changed.outputs.docs_changed == 'True' -or ${{ github.event.label.name == 'force_tests' }} -and steps.check_file_changed.weblate_tests.run != 'True'
+      if: ${{(steps.check_file_changed.outputs.docs_changed == 'True' || github.event.label.name == 'force_tests') && steps.check_file_changed.weblate_tests.run != 'True'}}
       run: |
         build-tools/github/validate --all
     - name: Run non-code related tests
       shell: pwsh
-      if: steps.check_file_changed.outputs.docs_changed != 'True' -and steps.check_file_changed.weblate_tests.run != 'True'
+      if: ${{steps.check_file_changed.outputs.docs_changed != 'True' && steps.check_file_changed.weblate_tests.run != 'True'}}
       run: |
         build-tools/github/validate

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -44,6 +44,11 @@ jobs:
         $SourceDiff = $diff | Where-Object { $_ -match '^content/' -or $_ -match '^grammars/' -or $_ -match '^highlighting/' -or $_ -match '^tests/' -or $_ -match '^app.py' -or $_ -match '^hedy.py'}
         $HasDiff = $SourceDiff.Length -gt 0
         Write-Host "::set-output name=docs_changed::$HasDiff"
+    - name: Run weblate tests
+      shell: pwsh
+      run: |
+        build-tools/github/validate --weblate
+        exit 1
     - name: Run all tests
       shell: pwsh
       if: steps.check_file_changed.outputs.docs_changed == 'True' -or ${{ github.event.label.name == 'force_tests' }}

--- a/build-tools/github/validate
+++ b/build-tools/github/validate
@@ -10,6 +10,8 @@ $scriptdir/validate-typescript
 $scriptdir/validate-yaml
 if [[ "${1:-}" == "--all" ]]; then
   $scriptdir/validate-tests --all
+if [[ "${1:-}" == "--weblate" ]]; then
+  $scriptdir/validate-tests --weblate
 else
   $scriptdir/validate-tests
 fi

--- a/build-tools/github/validate
+++ b/build-tools/github/validate
@@ -10,7 +10,7 @@ $scriptdir/validate-typescript
 $scriptdir/validate-yaml
 if [[ "${1:-}" == "--all" ]]; then
   $scriptdir/validate-tests --all
-if [[ "${1:-}" == "--weblate" ]]; then
+elif [[ "${1:-}" == "--weblate" ]]; then
   $scriptdir/validate-tests --weblate
 else
   $scriptdir/validate-tests

--- a/build-tools/github/validate-tests
+++ b/build-tools/github/validate-tests
@@ -12,6 +12,8 @@ echo "------> Python unit tests"
 # This is expected to run from the repo root
 if [[ "${1:-}" == "--all" ]]; then
   python -m pytest
+elif [[ "${1:-}" == "--weblate" ]]; then
+  python -m pytest tests/test_snippets
 else
   python -m pytest --ignore=tests/test_highlighting --ignore=tests/test_level --ignore=tests/test_snippets --ignore=tests/test_translation_level
 fi


### PR DESCRIPTION
**Description**
In this PR we expand our Github actions file to only run the snippet tests when a PR comes from Weblate. As we know this PR can only contain content changes we should be fine by only validating the code snippets. This highly speeds up the process of testing. We do have to keep in mind that, if for some reason, the Weblate translations break the front-end we don't test this any longer.

**Fixes**
This PR fixes #3652.

**How to test**
Merge this PR, re-run the jobs for a weblate PR and verify that only the snippets are tested.