### PR TITLE
[BACKEND] ICU MessageFormat support

### DIFF
--- a/app.py
+++ b/app.py
@@ -581,7 +581,7 @@ def translate_error(code, arguments, keyword_lang):
 
 def translate_list(args):
     # Deduplication is needed because diff values could be translated to the same value, e.g. int and float => a number
-    translated_args = {gettext(a) for a in args}
+    translated_args = list({gettext(a) for a in args})
 
     if len(translated_args) > 1:
         return f"{', '.join(translated_args[0:-1])}" \

--- a/app.py
+++ b/app.py
@@ -575,8 +575,6 @@ def translate_error(code, arguments, keyword_lang):
                 # Arguments ("tip") may themsleves be patterns, making formatting necessary here
                 arguments[k] = gettext(v, **arguments)
 
-    print(arguments)
-
     error_template = gettext(code, **arguments)
     return error_template
 

--- a/app.py
+++ b/app.py
@@ -579,9 +579,6 @@ def translate_error(code, arguments, keyword_lang):
     return error_template
 
 
-
-
-
 def translate_list(args):
     # Deduplication is needed because diff values could be translated to the same value, e.g. int and float => a number
     translated_args = {gettext(a) for a in args}

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -3,6 +3,7 @@ import os
 import logging
 
 from babel import Locale, languages
+from icu_i18n import icu_format
 
 from utils import customize_babel_locale
 from website.yaml_file import YamlFile
@@ -299,7 +300,7 @@ for l in sorted(languages):
         ALL_KEYWORD_LANGUAGES[l] = l[0:2].upper()  # first two characters
 
 # Load and cache all keyword yamls
-KEYWORDS = {}
+KEYWORDS: dict[str, dict[str, str]] = {}
 for lang in ALL_KEYWORD_LANGUAGES.keys():
     KEYWORDS[lang] = dict(YamlFile.for_file(f'content/keywords/{lang}.yaml'))
     for k, v in KEYWORDS[lang].items():
@@ -337,7 +338,7 @@ class Commands:
             for command in commands:
                 for k, v in command.items():
                     try:
-                        command[k] = v.format(**KEYWORDS.get(language))
+                        command[k] = icu_format(v, KEYWORDS.get(language, {}))
                     except IndexError:
                         logger.error(
                             f"There is an issue due to an empty placeholder in line: {v}")
@@ -393,7 +394,7 @@ class Adventures:
             for level in adventure.get('levels'):
                 for k, v in adventure.get('levels').get(level).items():
                     try:
-                        parsed_adventure.get('levels').get(level)[k] = v.format(**KEYWORDS.get(language))
+                        parsed_adventure.get('levels').get(level)[k] = icu_format(v, KEYWORDS.get(language, {}))
                     except IndexError:
                         logger.error(
                             f"There is an issue due to an empty placeholder in line: {v}")
@@ -474,7 +475,7 @@ class ParsonsProblem:
             for number, exercise in exercises.items():
                 for k, v in exercise.get('code_lines').items():
                     try:
-                        exercises.get(number).get('code_lines')[k] = v.format(**KEYWORDS.get(language))
+                        exercises.get(number).get('code_lines')[k] = icu_format(v, KEYWORDS.get(language, {}))
                     except IndexError:
                         logger.error(
                             f"There is an issue due to an empty placeholder in line: {v}")
@@ -535,11 +536,11 @@ class Quizzes:
                         for option in copy.deepcopy(v):
                             temp = {}
                             for key, value in option.items():
-                                temp[key] = value.format(**KEYWORDS.get(language))
+                                temp[key] = icu_format(value, KEYWORDS.get(language, {}))
                             options.append(temp)
                         questions[number][k] = options
                     else:
-                        questions[number][k] = v.format(**KEYWORDS.get(language))
+                        questions[number][k] = icu_format(v, KEYWORDS.get(language, {}))
             keyword_data[level] = questions
         return keyword_data
 
@@ -591,7 +592,7 @@ class Tutorials:
         for level in copy.deepcopy(self.file):
             steps = copy.deepcopy(self.file).get(level).get('steps')
             for index, data in steps.items():
-                steps[index]['text'] = data['text'].format(**KEYWORDS.get(language))
+                steps[index]['text'] = icu_format(data['text'], KEYWORDS.get(language, {}))
             tutorial_data[level] = steps
         return tutorial_data
 

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -190,7 +190,7 @@ ADVENTURE_ORDER_PER_LEVEL = {
         'story',
         'fortune',
         'restaurant',
-        'calculator',  
+        'calculator',
         'next',
         'end'
     ],
@@ -209,7 +209,7 @@ ADVENTURE_ORDER_PER_LEVEL = {
         'songs',
         'restaurant',
         'calculator',
-        'piggybank',  
+        'piggybank',
         'secret',
         'next',
         'end'
@@ -309,8 +309,6 @@ for lang in ALL_KEYWORD_LANGUAGES.keys():
             KEYWORDS[lang][k] = v.split('|')[0]
 
 
-
-
 class Commands:
     # Want to parse the keywords only once, they can be cached -> perform this action on server start
     def __init__(self, language):
@@ -360,6 +358,7 @@ class Commands:
 class NoSuchCommand:
     def get_commands_for_level(self, level, keyword_lang):
         return {}
+
 
 class Adventures:
     def __init__(self, language):
@@ -445,13 +444,14 @@ class Adventures:
                 self.file = YamlFile.for_file(
                     f'content/adventures/{self.language}.yaml').get('adventures')
             self.data["en"] = self.cache_adventure_keywords("en")
-        return True if self.data.get("en") else False     
-      
+        return True if self.data.get("en") else False
+
+
 # Todo TB -> We don't need these anymore as we guarantee with Weblate that each language file is there
 class NoSuchAdventure:
-  def get_adventure(self):
-    return {}
-  
+    def get_adventure(self):
+        return {}
+
 
 class ParsonsProblem:
     def __init__(self, language):
@@ -609,6 +609,7 @@ class Tutorials:
         if level not in ["intro", "teacher"]:
             level = int(level)
         return self.data.get(keyword_lang, {}).get(level, {}).get(step, None)
+
 
 class NoSuchTutorial:
     def get_tutorial_for_level(self, level, keyword_lang):

--- a/hedyweb.py
+++ b/hedyweb.py
@@ -1,7 +1,5 @@
 import collections
 
-from flask_babel import gettext
-
 from website.yaml_file import YamlFile
 import attr
 import glob

--- a/icu_i18n.py
+++ b/icu_i18n.py
@@ -1,23 +1,21 @@
-"""Enchance babel's gettext with ICU MessageFormat substitution
-"""
-# pylint: disable=no-member
 import icu
 from flask_babel import gettext as babel_gettext
-
 
 
 def _keys_to_argnames(param_dict: dict):
     return list(map(str, param_dict.keys()))
 
+
 def _vals_to_args(param_dict: dict):
     return list(map(icu.Formattable, param_dict.values()))
 
 
-def icu_format(pattern: str, argdict = {}):
+def icu_format(pattern: str, argdict={}):
     """Replace ICU MessageFormat arguments in pattern"""
     argnames = _keys_to_argnames(argdict)
     args = _vals_to_args(argdict)
     return icu.MessageFormat(pattern).format(argnames, args)
+
 
 def gettext(key: str, **kwargs):
     """Wraps Babel's gettext with MessageFormat argument substitution

--- a/icu_i18n.py
+++ b/icu_i18n.py
@@ -1,0 +1,27 @@
+"""Enchance babel's gettext with ICU MessageFormat substitution
+"""
+# pylint: disable=no-member
+import icu
+from flask_babel import gettext as babel_gettext
+
+
+
+def _keys_to_argnames(param_dict: dict):
+    return list(map(str, param_dict.keys()))
+
+def _vals_to_args(param_dict: dict):
+    return list(map(icu.Formattable, param_dict.values()))
+
+
+def icu_format(pattern: str, argdict = {}):
+    """Replace ICU MessageFormat arguments in pattern"""
+    argnames = _keys_to_argnames(argdict)
+    args = _vals_to_args(argdict)
+    return icu.MessageFormat(pattern).format(argnames, args)
+
+def gettext(key: str, **kwargs):
+    """Wraps Babel's gettext with MessageFormat argument substitution
+        Use ICU pluralization instead of Babel's.
+    """
+    pattern = babel_gettext(key)
+    return icu_format(pattern, kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ retrying==1.3.3
 pytest==6.2.5
 parameterized==0.8.1
 Flask-Babel==2.0.0
+pyicu-binary==2.7.4
 iso3166~=2.0.2
 turtlethread>=0.0.6

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,8 @@ import string
 import random
 import uuid
 
-from flask_babel import gettext, format_date, format_datetime, format_timedelta
+from flask_babel import format_date, format_datetime, format_timedelta
+from icu_i18n import gettext
 from ruamel import yaml
 import commonmark
 


### PR DESCRIPTION
### Description

**Adds** requirement for PyICU-binary package
**Adds** icu_i18n.py which exports a gettext wrapper and ICU formatter method

**Removes** import of babel's gettext from app.py, utils.py and hedyweb.py
**Adds** import of gettext from icu_i18n.py to app.py and utils.py
**Refactors** translate_error and translate_list in app.py

**Removes** str.format calls from hedy_content.py
**Adds** calls to icu formater to hedy_content.py

**Fixes #3658**

### How to test

* This PR should introduce minimal or no changes in current behavior
* It should correctly process strings with ICU parameters, similar to "Place {ask, select, ask {an} other {a}} {ask} before the {echo}."
* It should do this regardless if the string is in a .mo file or a .yaml

### Checklist
  
- [x] Contains one of the PR categories in the name
- [ ] Describes changes in the format above
- [x] Links to an existing issue or discussion 
- [x] Has a "How to test" section
