### PR TITLE
[FIX] Fixes issue with french front-end error when running program

### DIFF
--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -139,7 +139,7 @@
     <div class="order-2 lg:order-4" id="code_related_buttons">
       <div class="flex justify-between gap-2 items-start h-12 overflow-visible">
         <div id="runButtonContainer">
-          <button id="runit" class="green-btn" onclick="hedyApp.runit({{ level }}, '{{ g.lang }}', '{{_('already_program_running')}}')">{{_('run_code_button')}} </button>
+          <button id="runit" class="green-btn" onclick='hedyApp.runit({{ level }}, "{{ g.lang }}", {{_('already_program_running')|tojson}})'>{{_('run_code_button')}} </button>
           <button id="stopit" class="red-btn" onclick="hedyApp.stopit()" style="display: none;">{{_('stop_code_button')}}</button>
         </div>
         <div id="saveFilesContainer">


### PR DESCRIPTION
**Description**
In this PR we fix an issue with the `runit()` function that was broken in French. This was due to the default error message `already_programming_running` containing an `'` character. As the placeholder was also surrounded by `' '` to clarify as a string for Typescript the function broke. We fix this by using the Jinja2 function `|tojson` to always safely escape html special characters.

**Fixes**
This PR fixes #3661

**How to test**
Verify that Hedy works again in French.