### PR TITLE
[CHORE] Install Python and dependencies in JavaScript action

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -24,6 +24,15 @@ jobs:
       run: |
         npm ci
 
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install Python dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install -r requirements.txt
+
     - name: Compile TypeScript to JavaScript
       run: build-tools/heroku/generate-grammars-and-js
 


### PR DESCRIPTION
This script historically never needed Python, so didn't do `pip install`. 

It now does, so we need to add `pip install` as well.

**How to test**

After merging, the Update JavaScript action will run successfully, even if `import regex` appears in a Python script.