### PR TITLE
[CHORE] JavaScript compilation workflow broken for forks

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -16,12 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 1
-
-        # This is necessary to bypass branch protection (which will disallow non-reviewed pushes otherwise)
-        token: ${{ secrets.FELIENNE_GITHUB_ACCESS_TOKEN }}
-        
-        # This is necessary to check out the 
+        fetch-depth: 1        
     - name: Install Nodejs dependencies
       run: |
         npm ci


### PR DESCRIPTION
The secret token is not accessible in forks, so we can't pass it.

We only need it for the actual `push` anyway, so we can remove it and use the default workflow token.

**How to test**

After merging, the workflow will no longer fail for forked PRs.