### PR TITLE
[CHORE] JavaScript flow: use push token on checkout

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -15,6 +15,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      name: Checkout branch (with token)
+      if: github.event_name == 'push'
+      with:
+        fetch-depth: 1        
+        
+        # We need to pass the token here -- the commit action below will not overwrite the token to push.
+        token: ${{ secrets.FELIENNE_GITHUB_ACCESS_TOKEN }}
+    - uses: actions/checkout@v3
+      name: Checkout branch (on pull requests)
+      if: github.event_name != 'push'
       with:
         fetch-depth: 1        
     - name: Install Nodejs dependencies


### PR DESCRIPTION
We need to check out the source with a push-enabled token, otherwise the commit action later on will fail. Never mind that we pass that the correct token, it will not overwrite the token in the git checkout.

**How to test**
Run more workflows and see if they fail.