### PR TITLE
[TESTING, CYPRESS] Tests for fields on create account page

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -109,11 +109,11 @@
                     <ul class="signup-input" style="margin-top: -0.3em">
                         <div class="flex flex-row gap-2">
                             <li class="flex flex-row items-center mr-5">
-                                <input type="radio" name="prog_experience" value="yes" onclick="$('#languages').show()" class="ltr:mr-2 rtl:ml-2">
+                                <input type="radio" name="prog_experience" value="yes" onclick="$('#languages').show()" class="ltr:mr-2 rtl: ml-2" id="prog_experience_yes">
                                 <label for="prog_experience"> {{_('yes')}}</label>
                             </li>
                             <li class="flex flex-row items-center">
-                                <input type="radio" name="prog_experience" value="no" onclick="$('#languages').hide()" class="ltr:mr-2 rtl:ml-2">
+                                <input type="radio" name="prog_experience" value="no" onclick="$('#languages').hide()" class="ltr:mr-2 rtl:ml-2" id="prog_experience_no">
                                 <label for="prog_experience"> {{_('no')}}</label>
                             </li>
                         </div>
@@ -137,7 +137,7 @@
                         </li>
                         <li class="flex">
                             <div class="flex flex-row items-center gap-2">
-                                <input type="checkbox" name="experience_languages" value="python">
+                                <input type="checkbox" name="experience_languages" value="python" id="experience_language_python">
                                 <label>Python</label>
                             </div>
                         </li>
@@ -173,7 +173,7 @@
 
                 </div>
                 <div class="flex">
-                    <button type="submit" class="green-btn mx-auto">{{_('create_account')}}</button>
+                    <button type="submit" class="green-btn mx-auto" id="submit_button">{{_('create_account')}}</button>
                 </div>
             </form>
         </div>

--- a/tests/cypress/e2e/signup_page/birthyear_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/birthyear_create_account.cy.js
@@ -1,0 +1,18 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests username field interaction
+       cy.get('#birth_year')
+      .should('be.visible')
+      .should('be.empty')
+      .type('2000')
+      .should('have.value', '2000');
+  })
+})

--- a/tests/cypress/e2e/signup_page/country_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/country_create_account.cy.js
@@ -1,0 +1,16 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests preferred language field interaction
+       cy.get('#country').select('Australia').should('have.value', 'AU')
+      .should('be.visible')
+
+  })
+})

--- a/tests/cypress/e2e/signup_page/email_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/email_create_account.cy.js
@@ -1,0 +1,18 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests email field interaction
+       cy.get('#email')
+      .should('be.visible')
+      .should('be.empty')
+      .type('arandomemail@gmail.com')
+      .should('have.value', 'arandomemail@gmail.com');
+  })
+})

--- a/tests/cypress/e2e/signup_page/gender_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/gender_create_account.cy.js
@@ -1,0 +1,16 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests preferred language field interaction
+       cy.get('#gender').select('Female').should('have.value', 'f')
+      .should('be.visible')
+
+  })
+})

--- a/tests/cypress/e2e/signup_page/language_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/language_create_account.cy.js
@@ -1,0 +1,16 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests preferred language field interaction
+       cy.get('#language').select('English').should('have.value', 'en')
+      .should('be.visible')
+
+  })
+})

--- a/tests/cypress/e2e/signup_page/newsletter_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/newsletter_create_account.cy.js
@@ -1,0 +1,15 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests username field interaction
+       cy.get('#subscribe').check()
+      .should('be.visible')
+  })
+})

--- a/tests/cypress/e2e/signup_page/password_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/password_create_account.cy.js
@@ -1,0 +1,31 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests password field interaction
+       const some_password = 'some_password\"!#@\'( )*$%\'123\"'
+       cy.get('#password')
+      .should('be.visible')
+      .should('be.empty')
+      .should('have.attr', 'type', 'password')
+      .type(some_password)
+      .should('have.value', some_password);
+
+    // Tests password repeat field interaction
+
+      cy.get('#password_repeat')
+      .should('be.visible')
+      .should('be.empty')
+      .should('have.attr', 'type', 'password')
+      .type(some_password)
+      .should('have.value', some_password);
+
+
+  })
+})

--- a/tests/cypress/e2e/signup_page/privacyterms_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/privacyterms_create_account.cy.js
@@ -1,0 +1,15 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests username field interaction
+       cy.get('#agree_terms').check()
+      .should('be.visible')
+  })
+})

--- a/tests/cypress/e2e/signup_page/programming_experience_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/programming_experience_create_account.cy.js
@@ -1,0 +1,30 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests programming experience checkbox interaction
+
+        // Checks the 'no' button
+        cy.get('#prog_experience_no')
+        .should('be.visible')
+        .check()
+
+        // before checking the 'Yes' checkbox, programming languages should not be visible
+       cy.get('#experience_language_python')
+       .should('not.be.visible')
+       cy.get('#prog_experience_yes')
+       .should('be.visible')
+       .check()
+        // After checking the 'Yes' checkbox, programming languages should  be visible
+       cy.get('#experience_language_python')
+       .should('be.visible')
+       .check()
+
+  })
+})

--- a/tests/cypress/e2e/signup_page/username_create_account.cy.js
+++ b/tests/cypress/e2e/signup_page/username_create_account.cy.js
@@ -1,0 +1,18 @@
+import {goToLogin, gotoRegisterTeacher, goToPage, gotoRegisterStudent} from '../tools/navigation/nav.js'
+import {login, loginForUser} from '../tools/login/login.js'
+
+describe('Username field test', () => {
+  it('passes', () => {
+    goToPage(Cypress.env('register_student_page'));
+
+//      goToRegisterStudent();
+// This function is not working yet. Preferably we use the goToRegisterStudent function instead of the goToPage function.
+
+    // Tests username field interaction
+       cy.get('#username')
+      .should('be.visible')
+      .should('be.empty')
+      .type('some_username123')
+      .should('have.value', 'some_username123');
+  })
+})


### PR DESCRIPTION
**Description**

This includes the tests for the fields of the sign-up page

**Fixes _issue or discussion number_**

Fixes #3729 

**How to test**

Run 
`export ADMIN_USER=admin_user; python app.py` in your virtual environment. This ensures that there is an active admin_user and Hedy is running.

Then you can go to the /tests folder and run: 

`npx cypress run --spec cypress/e2e/signup_page`
