### PR TITLE
[CHORE, TESTING] Updating the action tester, again

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,7 +53,7 @@ jobs:
         build-tools/github/validate --weblate
     - name: Run all tests
       shell: pwsh
-      if: ${{(steps.check_file_changed.outputs.docs_changed == 'True' || github.event.label.name == 'force_tests') && steps.check_file_changed.weblate_tests.run != 'True'}}
+      if: ${{(steps.check_file_changed.outputs.docs_changed == 'True' || github.event.label.name == 'force_tests') && steps.weblate_tests.run != 'True'}}
       run: |
         build-tools/github/validate --all
     - name: Run non-code related tests


### PR DESCRIPTION
Somehow #3744 did not stick on main: 

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1003685/205043215-6cc4b7e3-4ff0-4812-ad83-312b6f02ea19.png">

Trying again (and I will now bypass mergify manually, maybe that was the cause?)


