### PR TITLE
[CHORE] Removes view columns on classes overview

### DIFF
--- a/templates/for-teachers.html
+++ b/templates/for-teachers.html
@@ -20,7 +20,6 @@
                   <th class="px-4 py-2 text-left">{{_('name')}}</th>
                   <!-- This is a bucket-fix to get the first letter capitalized, should find a long-term solution -->
                   <th class="px-4 py-2">{{_('students')[0]|upper}}{{_('students')[1:]}}</th>
-                  <th class="p-2">{{_('view')}}</th>
                   <th class="p-2">{{_('duplicate')}}</th>
                   <th class="p-2">{{_('remove')}}</th>
               </tr>
@@ -28,9 +27,8 @@
             <tbody>
               {% for class in teacher_classes %}
                 <tr>
-                  <td class="px-4 py-2">{{class.name|e}}</td>
+                  <td class="px-4 py-2"><a href="for-teachers/class/{{class.id}}">{{class.name|e}}</a></td>
                   <td class="text-center p-2">{{class.students|length}}</td>
-                  <td class="text-center p-2" id="class_view_button"><a class="no-underline" href="for-teachers/class/{{class.id}}">👁</a></td>
                   <td class="text-center p-2"><a class="no-underline cursor-pointer" onclick='hedyApp.duplicate_class("{{class.id}}", {{_('class_name_prompt')|tojson}})')><span class="fas fa-copy"></span></a></td>
                   <td class="text-center p-2"><a class="no-underline cursor-pointer" onclick='hedyApp.delete_class("{{class.id}}", {{_('delete_class_prompt')|tojson}})'>🗑️</a></td>
                 </tr>


### PR DESCRIPTION
**Description**
In this PR we remove the view column on the classes overview page and make the name clickable instead.

**Fixes**
This PR fixes #3776

**How to test**
Verify that you can navigate to a class by clicking the name now that the eye symbol is gone.
