### PR TITLE
[BUG] GitHub Actions Error "ALSA lib ..."

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -89,6 +89,7 @@ NORMAL_PREFIX_CODE = textwrap.dedent("""\
 PYGAME_PREFIX_CODE = textwrap.dedent("""\
     # coding=utf8
     os.environ["SDL_VIDEODRIVER"] = "dummy" # No real image drivers exist, set to dummy for testing
+    os.environ["SDL_AUDIODRIVER"] = "disk" # No real audio drivers exist, set to disk for testing
     import pygame
     pygame.init()
     canvas = pygame.display.set_mode((711,300))


### PR DESCRIPTION
Fixes #3793. it sets the audio drivers for PyGame to _disk_ (essentially a dummy driver). 

Found on: https://stackoverflow.com/questions/72311056/alsa-not-found-github-actions-unit-testing-setting-env-envvars-correctly