### PR TITLE
[TESTING, CYPRESS] 3566 front-end tests for the logs page

### DIFF
--- a/templates/class-logs.html
+++ b/templates/class-logs.html
@@ -6,7 +6,7 @@
 <div>
   <div class="inline-block medium text-2xl">Search class programs: </div>
 
-    <button class="green-btn float-right" onclick="window.location.href='/for-teachers/class/{{class_info.id}}'">
+    <button class="green-btn float-right" id="to_class_button" onclick="window.location.href='/for-teachers/class/{{class_info.id}}'">
       {{_('back_to_class')}}
     </button>
 

--- a/tests/cypress/e2e/for-teacher_page/class_page/logs_page/exception_field.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/logs_page/exception_field.cy.js
@@ -1,0 +1,20 @@
+import {loginForAdmin, loginForTeacher} from '../../../tools/login/login.js'
+import {createClass} from '../../../tools/classes/class.js'
+
+
+describe('Is able to enter an exception', () => {
+  it('Passes', () => {
+    loginForTeacher();
+    cy.wait(500);
+    createClass();
+    cy.get(".view_class").first().click(); // Press view class button from test class
+
+    cy.get('#logs_button').click();
+    
+    cy.get('#logs-exception')
+      .should('be.visible')
+      .should('be.empty')
+      .type('ParseException')
+      .should('have.value', 'ParseException');
+  })
+})

--- a/tests/cypress/e2e/for-teacher_page/class_page/logs_page/level_field.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/logs_page/level_field.cy.js
@@ -1,0 +1,20 @@
+import {loginForAdmin, loginForTeacher} from '../../../tools/login/login.js'
+import {createClass} from '../../../tools/classes/class.js'
+
+
+describe('Is able to enter a level to be searched', () => {
+  it('Passes', () => {
+    loginForTeacher();
+    cy.wait(500);
+    createClass();
+    cy.get(".view_class").first().click(); // Press view class button from test class
+
+    cy.get('#logs_button').click();
+    
+    cy.get('#logs-level')
+      .should('be.visible')
+      .should('be.empty')
+      .type('1')
+      .should('have.value', '1');
+  })
+})

--- a/tests/cypress/e2e/for-teacher_page/class_page/logs_page/logs_to_class.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/logs_page/logs_to_class.cy.js
@@ -1,0 +1,23 @@
+import {loginForAdmin, loginForTeacher} from '../../../tools/login/login.js'
+import {createClass} from '../../../tools/classes/class.js'
+
+
+describe('Is able to go back to teacher page', () => {
+  it('Passes', () => {
+    loginForTeacher();
+    cy.wait(500);
+    createClass();
+    cy.get(".view_class").first().click();
+
+    var currentUrl = '';
+    cy.url().then(currentUrl => {
+      cy.get('#logs_button').click(); // Press the logs button
+
+      cy.wait(500);
+
+      cy.get('#to_class_button').click(); // Press go back to class button
+      cy.url().should('eq', currentUrl); // Check if you go back to the correct page
+    })
+  
+  })
+})

--- a/tests/cypress/e2e/for-teacher_page/class_page/logs_page/search_button.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/logs_page/search_button.cy.js
@@ -1,0 +1,16 @@
+import {loginForTeacher} from '../../../tools/login/login.js'
+import {createClass} from '../../../tools/classes/class.js'
+
+
+describe('Is able to press the search button', () => {
+  it('Passes', () => {
+    loginForTeacher();
+    cy.wait(500);
+    createClass();
+    cy.get(".view_class").first().click();
+    cy.get('#logs_button').click();
+
+    cy.get('#search-logs-button').click();
+    cy.get('#search-logs-failed-msg').should('be.visible');
+  })
+})


### PR DESCRIPTION
[TESTING]

**Description**
These tests test the search button, go back to class button and filtering options on the `/logs/class` page. I was not able to test the username field because I'm waiting on issue #3562 to be completed because then students can be added.

**Fixes _issue or discussion number_**
Fixes #3566 

**How to test**
These tests uses the accounts in the test database, to use this the database has to be fed first by running bash `feed_dev_database.sh` in the hedy (root) directory.
To run the tests on the command, do the the following: `npx cypress run --spec tests/cypress/e2e/for-teacher_page/class_page/logs_page`
This tests all the logs page tests.
