### PR TITLE
[CHORE] Update pre-commit config to include autopep8 before flake8 linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.4
+    hooks:
+    -   id: autopep8
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:


### PR DESCRIPTION
**Now fill out the remainder of this template by replacing all _italic_ content**

**Description**

This PR updates the .pre-commit-config.yaml file to apply autopep8 autoformatting before doing a final check using flake8. 

**Fixes #3377 **

**How to test**
Install the pre-commit locally using `pre-commit install`, or better yet: let's set up pre-commit.ci to automatically do it for us :) 