### PR TITLE
[FIX] Design: remove scroll bars

### DIFF
--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -9,7 +9,7 @@
       </div>
   </div>
 {% endif %}
-<div tabindex="0" class="flex-grow p-4 overflow-y-scroll">
+<div tabindex="0" class="flex-grow p-4 overflow-y">
     {# When we're NOT in adventure mode but DO have adventures, render them in tabs #}
     {% include "incl-adventure-tabs.html" %}
 

--- a/templates/incl-adventure-tabs.html
+++ b/templates/incl-adventure-tabs.html
@@ -1,6 +1,6 @@
       {# TABS #}
       <div id="adventures">
-        <div class="flex flex-row overflow-x-scroll overflow-y-hidden px-2 pt-2" id="adventures-buttons">
+        <div class="flex flex-row overflow-x-auto overflow-y-hidden px-2 pt-2" id="adventures-buttons">
             {% for adventure in adventures %}
               {% if 'adventures' not in customizations or (customizations['adventures'][adventure.short_name] and level|int in customizations['adventures'][adventure.short_name]) %}
                 <div class="tab {% if loop.index == 1 %}tab-selected{% endif %} z-10 whitespace-nowrap flex items-center justify-center" id="adventure{{ loop.index }}" tabindex="0" data-tab="{{adventure.short_name}}">


### PR DESCRIPTION
On non-Safari browsers, scroll bars take up horizontal and vertical space.

Remove two causes of unnecessary space between elements.

## Before

![2023-01-02 at 15 41](https://user-images.githubusercontent.com/524162/210246164-b68b329c-9f75-44c9-a153-a985086f9fb2.png)

## After

![image](https://user-images.githubusercontent.com/524162/210246215-db90cec6-cd60-4ff8-865c-2e8c5174f5cc.png)
