### PR TITLE
[FIX] typo in level 4 quiz

### DIFF
--- a/content/quizzes/en.yaml
+++ b/content/quizzes/en.yaml
@@ -838,7 +838,7 @@ levels:
                 feedback: "Hedy could `{print}` that"
             -   option: "Real Madrid is going to win the champions league"
                 feedback: "Hedy could `{print}` that"
-            -   option: "Bayer Munchen is going to win the champions league"
+            -   option: "Bayern Munchen is going to win the champions league"
                 feedback: "Hedy could `{print}` that"
             -   option: "FC Barcelona is going to win the champions league"
                 feedback: "That's right. It's not in the list"


### PR DESCRIPTION
**Description**

Fix typo in level 4 quiz -- `Bayer` instead of `Bayern`.

**How to test**

* Just go to question 9 in the level 4 quiz and see the question and answers.

**Checklist**
Done? Check if you have it all in place using this list:
  
- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [ ] Links to an existing issue or discussion 
- [x] Has a "How to test" section

I'm also not sure if `Munchen` should be spelled `München`?