### PR TITLE
[CHORE] Run hashes every day

### DIFF
--- a/.github/workflows/generate-snippet-hashes.yml
+++ b/.github/workflows/generate-snippet-hashes.yml
@@ -4,7 +4,7 @@ env:
 name: Periodically generate hashes
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
   workflow_dispatch: {} # Allow running the workflow on-demand
 jobs:
   build:


### PR DESCRIPTION
We now save hashes for test runner speed (see #3873) But... Every week is not really enough to prevent looooong waits... why not every day (it is free, after all!)

