### PR TITLE
[FIX] Design: output height

### DIFF
--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -104,7 +104,7 @@
         </div>
       </div>
     </div>
-    <div class="w-full flex flex-col order-3 relative" id="code_output" style="min-height: 22rem;">
+    <div class="w-full flex flex-col order-3 relative" id="code_output" style="height: 22rem;">
         <div class="inline-block ltr:right-0 rtl:left-0 absolute z-10 mx-2 mt-2 text-white" id="variables_container">
             <button id="variable_button" class="inline-flex items-center text-xl px-2 bg-blue-600 rounded-lg" onclick="hedyApp.showVariableView()">
                 🏷<svg class="float-right w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -117,7 +117,7 @@
             </div>
         </div>
       <!-- tabindex=0 makes the div focusable -->
-      <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem; max-height: 22rem;"></div>
+      <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem;"></div>
       <div id="turtlecanvas" class="flex-0 ltr:pl-4 rtl:pr-4"></div>
       <div id="inline-modal" class="flex-0">
         <div id="ask-modal" class="py-2 text-left px-3 border-4 border-teal-500 mt-3 rounded bg-green-100" style="display: none">


### PR DESCRIPTION
A different fix for the code editor scrollbar, one that is compatible with the *programmer's mode* toggle.

Right now, it works by putting fixed heights (`22rem` and `36rem`) on the elements.

**How to test**

http://localhost:8080/hedy/7

```
repeat 30 times print 'Hedy is fun!'
```

See a scrollbar. Toggle programmmer's mode.

Fixes #https://github.com/hedyorg/hedy/issues/3982.