### PR TITLE
[FIX, LANGUAGE] Allow punctuation after random

### DIFF
--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -1,5 +1,5 @@
 command:+= assign_list | add | remove > error_invalid   
-_print_argument: (_SPACE | list_access | textwithoutspaces)*
+_print_argument: (_SPACE | (list_access textwithoutspaces?) | textwithoutspaces)*
 ask: var _IS _ASK ((_SPACE | text_ask)*)?
 
 assign: var _IS (list_access | text) -> assign

--- a/hedy.py
+++ b/hedy.py
@@ -1565,6 +1565,7 @@ class ConvertToPython_2(ConvertToPython_1):
             if "random.choice" in a or "[" in a:
                 args_new.append(self.process_variable_for_fstring(a, meta.line))
             else:
+                # this regex splits words from non-letter characters, such that name! becomes [name, !]
                 res = regex.findall(
                     r"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}]+|[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]+", a)
                 args_new.append(''.join([self.process_variable_for_fstring(x, meta.line) for x in res]))

--- a/tests/test_level/test_level_03.py
+++ b/tests/test_level/test_level_03.py
@@ -54,6 +54,36 @@ class TestsLevel3(HedyTester):
             extra_check_function=check_in_list
         )
 
+    def test_print_list_random_punctuation(self):
+        code = textwrap.dedent("""\
+        gerechten is spaghetti, spruitjes, hamburgers
+        print Jij eet vanavond gerechten at random!""")
+
+        expected = HedyTester.dedent("gerechten = ['spaghetti', 'spruitjes', 'hamburgers']",
+                                     HedyTester.list_access_transpiled("random.choice(gerechten)"),
+                                     "print(f'Jij eet vanavond {random.choice(gerechten)} !')")
+
+        self.multi_level_tester(
+            max_level=3,
+            code=code,
+            expected=expected
+        )
+
+    def test_print_list_random_punctuation_2(self):
+        code = textwrap.dedent("""\
+        prijzen is 1 euro, 10 euro, 100 euro
+        print Dat wordt dan prijzen at random, alstublieft.""")
+
+        expected = HedyTester.dedent("prijzen = ['1 euro', '10 euro', '100 euro']",
+                                     HedyTester.list_access_transpiled("random.choice(prijzen)"),
+                                     "print(f'Dat wordt dan {random.choice(prijzen)} , alstublieft.')")
+
+        self.multi_level_tester(
+            max_level=3,
+            code=code,
+            expected=expected
+        )
+
     def test_print_list_access_index(self):
         code = textwrap.dedent("""\
         dieren is Hond, Kat, Kangoeroe


### PR DESCRIPTION
Fixes #4010. It now prints a space after a random but I guess that is ok for now (of course in level 4 this will be fixed anyway)