### PR TITLE
[FIX] Design: Language dropdown shows white underbar overlaying menu

### DIFF
--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -40,7 +40,8 @@
     {% else %}
       <!-- Not logged in -->
       <li class="menubar-item dropdown relative z-20">
-          <a class="menubar-text border-transparent cursor-pointer" onclick="$('.dropdown-menu').hide();$('#language-dropdown').slideToggle('medium');">
+          {# Needs a 'block' because it contains a flexbox child #}
+          <a class="menubar-text block border-transparent cursor-pointer" onclick="$('.dropdown-menu').hide();$('#language-dropdown').slideToggle('medium');">
             <div class="flex flex-row gap-2 items-center">
                 <i class="fas fa-fw fa-globe"></i>
                 <span class="hidden lg:flex">{{ current_language().sym }}</span>


### PR DESCRIPTION
A picture is worth a thousand words...

## Before

<img width="306" alt="image" src="https://user-images.githubusercontent.com/524162/217333064-0c9d5834-8d2a-405b-8e2a-85551477714e.png">

## After

<img width="310" alt="image" src="https://user-images.githubusercontent.com/524162/217333143-e4ea8995-cfa0-49f2-a4dc-815d85c7fdc6.png">
