### PR TITLE
 [UI] Removes thin styling from cheatsheets

### DIFF
--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -25,7 +25,7 @@
                 <h2 class="px-2 py-6">{{_('cheatsheet_title')}}</h2>
                 {% for example in cheatsheet %}
                   <div class="flex justify-between items-center gap-4 px-4 py-8 border-t border-dashed border-green-500">
-                    <div class="font-thin flex-grow h-min min-w-80" tabindex=0>
+                    <div class="flex-grow h-min min-w-80" tabindex=0>
                       {{ example.explanation|commonmark }}
                     </div>
                     <div class="flex-none">


### PR DESCRIPTION
**Description**

As stated in the title, removes the `font-thin` class from the cheatsheets making them easier to read!

![image](https://user-images.githubusercontent.com/45865185/218762086-228894d2-809a-4f02-ae29-9e78037b8384.png)


**Fixes #4030 **
