### PR TITLE
[CHORE] Automation of the texts translate with DeepL

### DIFF
--- a/content/slides/uk.yaml
+++ b/content/slides/uk.yaml
@@ -1,66 +1,115 @@
 levels:
-    0:
-        1:
-            text: "Hedy is a programming language.\n"
-            header: Welcome to Hedy!
-        2:
-            header: Programming
-            text: "Programming is giving instructions to a computer, using the language of the computer.\n\nSuch a language is called a \"programming language\".\n"
-        3:
-            header: Programming Language
-            text: "Maybe you already know some programming languages?\nSome examples are:\n* Scratch\n* Python\n* HTML\n"
-        4:
-            header: Programming
-            text: "If you can program, you can do many cool things:\n* Build interactive stories\n* Create computer drawings and draw these on paper or fabric\n* Build your own apps to use on your phone\n"
-        5:
-            header: Programming in Hedy
-            text: "In Hedy we use special codes, like `{print}`.\n<iframe class=\"embedded-hedy\" src=\"/adventure/story/1/raw\"></iframe>\n"
-        6:
-            header: Programming in Hedy
-            text: "Code words will be shown in pink.\n<iframe class=\"embedded-hedy\" src=\"/adventure/story/1/raw\"></iframe>\n"
-        7:
-            header: Programming in Hedy
-            text: "We start the code with the Run code button underneath the code.\n<iframe class=\"embedded-hedy\" src=\"/adventure/story/1/raw\"></iframe>\n"
-        8:
-            header: Programming in Hedy
-            text: "Output appears on the left-hand side.\n<iframe class=\"embedded-hedy\" src=\"/adventure/story/1/raw\"></iframe>\n"
-        9:
-            header: Programming in Hedy
-            text: "The output can also be a drawing.\n<iframe class=\"embedded-hedy\" src=\"/adventure/turtle/1/raw\"></iframe>\n"
+  0:
     1:
-        4:
-            header: 'Hedy level 1: {echo}'
-            text: "The final text code that you can use in level 1 is `{echo}`.\n\n`{echo}` is used to repeat the answer of an `{ask}`.\n"
-            editor: "<iframe class=\"fragment\" src=\"/adventure/parrot/1/raw\"></iframe>\n"
-        7:
-            header: Programming!
-            text: "The yellow arrow buttons can be used to copy examples.\n<iframe class=\"fragment\" src=\"/hedy/1\"></iframe>\n"
-        1:
-            header: Welcome to level 1!
-            text: "We will start level 1 by making stories in Hedy!\n\nWe need three text codes to create interactive stories.\n"
-        2:
-            header: 'Hedy level 1: {print}'
-            text: "The first code that you can use in level 1 is `{print}`.\n\n`{print}` is used to show text on the screen.\n"
-            editor: "<iframe class=\"fragment\" src=\"/adventure/story/1/raw\"></iframe>\n"
-        3:
-            header: 'Hedy level 1: {ask}'
-            text: "The second code that you can use in level 1 is `{ask}`.\n\n`{ask}` is used to ask a question that can be answered.\n"
-            editor: "<iframe class=\"fragment\" src=\"/adventure/rock/1/raw\"></iframe>\n"
-        5:
-            header: Programming!
-            text: "with `{print}`, `{ask}` and `{echo}` you can already create a little story.\nThis is a good time to try the Parrot, Story and Rock, Paper Scissors adventures.\n"
-        6:
-            header: Programming!
-            text: "Adventures are shown in tabs.\n"
-            editor: "<iframe class=\"fragment\" src=\"/hedy/1\"></iframe>\n"
-        8:
-            header: Drawing with the turtle
-            text: "Now that we have seen at text codes, we will now look at drawing codes next.\n"
-        9:
-            header: 'Drawing with the turtle: {forward}'
-            text: "`{forward}` is used to move the turtle forward.\n"
-            editor: "<iframe class=\"fragment\" src=\"/adventure/turtle/1/raw\"></iframe>\n"
-        10:
-            header: 'Drawing with the turtle: {turn}'
-            text: "`{turn}` is used to make the turtle turn left or right.\n"
-            editor: "<iframe class=\"fragment\" src=\"/adventure/turtle/1/raw\"></iframe>\n"
+      text: |
+        Hedy - це мова програмування.
+      header: Ласкаво просимо до Hedy!
+    2:
+      header: Програмування
+      text: |
+        Програмування - це надання інструкцій комп'ютеру, використовуючи мову комп'ютера.
+
+        Така мова називається "мовою програмування".
+    3:
+      header: Мова програмування
+      text: |
+        Може, ти вже знаєш деякі мови програмування?
+        Ось деякі приклади:
+        * Scratch
+        * Python
+        * HTML
+    4:
+      header: Програмування
+      text: |
+        Якщо ви вмієте програмувати, ви можете робити багато крутих речей:
+        * Створювати інтерактивні історії
+        * Створювати комп'ютерні малюнки та переносити їх на папір чи тканину
+        * Створювати власні додатки для використання на телефоні
+    5:
+      header: Програмування на Hedy
+      text: |
+        У Hedy ми використовуємо спеціальні коди, такі як `{print}`.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+    6:
+      header: Програмування на Hedy
+      text: |
+        Кодові слова будуть показані рожевим кольором.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+    7:
+      header: Програмування на Hedy
+      text: |
+        Запускаємо код за допомогою кнопки Запустити код під кодом.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+    8:
+      header: Програмування на Hedy
+      text: |
+        Вивід з'являється зліва.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+    9:
+      header: Програмування на Hedy
+      text: |
+        Виведенням також може бути малюнок.
+        <iframe class="embedded-hedy" src="/adventure/turtle/1/raw"></iframe></iframe>
+  1:
+    4:
+      header: 'Hedy рівень 1: {echo}'
+      text: |2
+         Кінцевий текстовий код, який ви можете використати на рівні 1: `{echo}`.
+
+        `{echo}` використовується для повторення відповіді на `{ask}`.
+      editor: |
+        <iframe class="fragment" src="/adventure/parrot/1/raw"></iframe>
+    7:
+      header: Програмування!
+      text: |
+        Кнопки з жовтими стрілками можна використовувати для копіювання прикладів.
+        <iframe class="fragment" src="/hedy/1"></iframe>
+    1:
+      header: Ласкаво просимо на рівень 1!
+      text: |
+        Ми почнемо рівень 1 зі створення історій у Hedy!
+
+        Нам потрібні три текстові коди для створення інтерактивних історій.
+    2:
+      header: 'Hedy рівень 1: {print}'
+      text: |
+        Перший код, який ви можете використати на рівні 1 - це `{print}`.
+
+        `{print}` використовується для виведення тексту на екран.
+      editor: |
+        <iframe class="fragment" src="/adventure/story/1/raw"></iframe>
+    3:
+      header: 'Рівень 1: {ask}'
+      text: |
+        Другий код, який ви можете використати на рівні 1, це `{ask}`.
+
+        `{ask}` використовується для того, щоб поставити запитання, на яке можна відповісти.
+      editor: |
+        <iframe class="fragment" src="/adventure/rock/1/raw"></iframe>
+    5:
+      header: Програмування!
+      text: |
+        за допомогою `{print}`, `{ask}` і `{echo}` ви вже можете створити невелику історію.
+        Це гарний час, щоб спробувати "Папугу", "Історію" та "Камінь, папір, ножиці".
+    6:
+      header: Програмування!
+      text: |
+        Пригоди показані у вкладках.
+      editor: |
+        <iframe class="fragment" src="/hedy/1"></iframe>
+    8:
+      header: Малюнок з черепахою
+      text: |
+        Тепер ми розглянули текстові коди, а тепер перейдемо до кодів малюнків.
+    9:
+      header: 'Малюнок з черепахою: {вперед}'
+      text: |
+        `{вперед}` використовується для переміщення черепахи вперед.
+      editor: |
+        <iframe class="fragment" src="/adventure/turtle/1/raw"></iframe>
+    10:
+      header: 'Малюнок з черепахою: {turn}'
+      text: |
+        `{turn}` використовується, щоб змусити черепаху повернутися вліво або вправо.
+      editor: |
+        <iframe class="fragment" src="/adventure/turtle/1/raw"></iframe>

--- a/content/slides/uk.yaml
+++ b/content/slides/uk.yaml
@@ -11,10 +11,10 @@ levels:
 
         Така мова називається "мовою програмування".
     3:
-      header: Мова програмування
+      header: Програмування
       text: |
         Може, ти вже знаєш деякі мови програмування?
-        Ось деякі приклади:
+        Наприклад:
         * Scratch
         * Python
         * HTML
@@ -28,28 +28,28 @@ levels:
     5:
       header: Програмування на Hedy
       text: |
-        У Hedy ми використовуємо спеціальні коди, такі як `{print}`.
-        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+        У Hedy ми використовуємо спеціальні команди, такі як `{print}`.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe>
     6:
       header: Програмування на Hedy
       text: |
         Кодові слова будуть показані рожевим кольором.
-        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe>
     7:
       header: Програмування на Hedy
       text: |
-        Запускаємо код за допомогою кнопки Запустити код під кодом.
-        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+        Запускаємо программу за допомогою кнопки Запустити код під вікном команд.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe>
     8:
       header: Програмування на Hedy
       text: |
-        Вивід з'являється зліва.
-        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe></iframe
+        Результат програми з'являється зліва.
+        <iframe class="embedded-hedy" src="/adventure/story/1/raw"></iframe>
     9:
       header: Програмування на Hedy
       text: |
-        Виведенням також може бути малюнок.
-        <iframe class="embedded-hedy" src="/adventure/turtle/1/raw"></iframe></iframe>
+        Результатом програми також може бути малюнок.
+        <iframe class="embedded-hedy" src="/adventure/turtle/1/raw"></iframe>
   1:
     4:
       header: 'Hedy рівень 1: {echo}'
@@ -69,11 +69,11 @@ levels:
       text: |
         Ми почнемо рівень 1 зі створення історій у Hedy!
 
-        Нам потрібні три текстові коди для створення інтерактивних історій.
+        Нам потрібні три текстові команди для створення інтерактивних історій.
     2:
       header: 'Hedy рівень 1: {print}'
       text: |
-        Перший код, який ви можете використати на рівні 1 - це `{print}`.
+        Перша команда, яку ви можете використати на рівні 1 - це `{print}`.
 
         `{print}` використовується для виведення тексту на екран.
       editor: |
@@ -81,7 +81,7 @@ levels:
     3:
       header: 'Рівень 1: {ask}'
       text: |
-        Другий код, який ви можете використати на рівні 1, це `{ask}`.
+        Другий команда, яку ви можете використати на рівні 1, це `{ask}`.
 
         `{ask}` використовується для того, щоб поставити запитання, на яке можна відповісти.
       editor: |
@@ -100,7 +100,7 @@ levels:
     8:
       header: Малюнок з черепахою
       text: |
-        Тепер ми розглянули текстові коди, а тепер перейдемо до кодів малюнків.
+        Тепер ми розглянули текстові команди, а тепер перейдемо до команд малюнків.
     9:
       header: 'Малюнок з черепахою: {вперед}'
       text: |

--- a/tools/kotlin/README.md
+++ b/tools/kotlin/README.md
@@ -1,0 +1,13 @@
+# Kotlin scripts
+
+## Run
+
+### Environment
+To run script you have to install kotlin on your system. 
+Check [the official page](https://kotlinlang.org/docs/command-line.html#install-the-compiler).
+
+### Execution
+Scripts are unix executable. Or run with 
+```bash
+kotlin <path to file>
+```

--- a/tools/kotlin/translate-content.main.kts
+++ b/tools/kotlin/translate-content.main.kts
@@ -5,8 +5,7 @@
 @file:DependsOn("com.deepl.api:deepl-java:1.1.0")
 
 import com.charleskorn.kaml.*
-import com.deepl.api.Language
-import com.deepl.api.Translator
+import com.deepl.api.*
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
@@ -64,8 +63,12 @@ class TranslateContent : CliktCommand(help = "Translate content file with DeepL"
             val translator = Translator(authKey)
             val result = translator.translateText(
                 textToTranslate,
-                Language("English", "en", true),
-                Language("Ukrainian", "uk", true),
+                "en",
+                language,
+                TextTranslationOptions().apply {
+                    isPreserveFormatting = true
+                    formality = Formality.PreferMore
+                }
             )
             val mapHashToTranslated = result.text
                 .split(translationSeparator)
@@ -86,7 +89,6 @@ class TranslateContent : CliktCommand(help = "Translate content file with DeepL"
                 }
 
             file.setWritable(true)
-            TODO("Find a way to write node to file")
 //            file.writeText(Yaml.default.encodeToString(translatedYaml))
         }
     }

--- a/tools/kotlin/translate-content.main.kts
+++ b/tools/kotlin/translate-content.main.kts
@@ -1,0 +1,108 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("com.github.ajalt.clikt:clikt-jvm:3.5.1")
+@file:DependsOn("com.charleskorn.kaml:kaml-jvm:0.51.0")
+@file:DependsOn("com.deepl.api:deepl-java:1.1.0")
+
+import com.charleskorn.kaml.*
+import com.deepl.api.Language
+import com.deepl.api.Translator
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+import kotlinx.serialization.encodeToString
+import java.io.File
+
+class TranslateContent : CliktCommand(help = "Translate content file with DeepL") {
+    private val contentFileOrRootDir: File by option("--content")
+        .help("Root directory for files search or file to translate")
+        .file()
+        .required()
+
+    private val language by option("--language")
+        .help("ISO code for language to translate")
+        .required()
+
+    private val authKey by option("--deepl-key")
+        .help("DeepL auth key")
+        .required()
+
+    override fun run() {
+        val files = if (contentFileOrRootDir.isFile) {
+            sequenceOf(contentFileOrRootDir)
+        } else {
+            contentFileOrRootDir.walkTopDown()
+                .filter { file ->
+                    file.name.startsWith(language)
+                }
+        }
+        files.forEach { file ->
+            val parsedYaml = Yaml.default.parseToYamlNode(file.readText())
+            val mapOfScalars = parsedYaml.yamlMap
+                .entries
+                .values
+                .map { it.toScalarList() }
+                .flatten()
+                .associateWith { it.content }
+
+            val translationSeparator = "#######"
+            val keyValueSeparator = "::::::"
+            val textToTranslate = mapOfScalars
+                .entries
+                .joinToString(translationSeparator) { (key, value) ->
+                    "${key.hashCode()}$keyValueSeparator$value"
+                }
+
+            val translator = Translator(authKey)
+            val result = translator.translateText(
+                textToTranslate,
+                Language("English", "en", true),
+                Language("Ukrainian", "uk", true),
+            )
+            val mapHashToTranslated = result.text
+                .split(translationSeparator)
+                .associate {
+                    val (hash, value) = it.split(keyValueSeparator)
+                    hash.toInt() to value
+                }
+
+
+            val translatedYaml = parsedYaml.yamlMap
+                .entries
+                .map {
+                    it.key to it.value.translate(mapHashToTranslated)
+                }.toMap()
+                .let {
+                    YamlMap(it, parsedYaml.yamlMap.path)
+                }
+
+            file.setWritable(true)
+            TODO("Find a way to write node to file")
+//            file.writeText(Yaml.default.encodeToString(translatedYaml))
+        }
+    }
+}
+
+fun YamlNode.toScalarList(): List<YamlScalar> {
+    return when (this) {
+        is YamlList -> items.map { it.toScalarList() }.flatten()
+        is YamlMap -> entries.map { it.value.toScalarList() }.flatten()
+        is YamlNull -> emptyList()
+        is YamlScalar -> listOf(this)
+        is YamlTaggedNode -> innerNode.toScalarList()
+    }
+}
+
+fun YamlNode.translate(translations: Map<Int, String>): YamlNode {
+    return when (this) {
+        is YamlList -> YamlList(items.map { it.translate(translations) }, path)
+        is YamlMap -> YamlMap(this.entries.map { it.key to it.value.translate(translations) }.toMap(), path)
+        is YamlNull -> this
+        is YamlScalar -> YamlScalar(translations[hashCode()]!!, path)
+        is YamlTaggedNode -> YamlTaggedNode(tag, innerNode.translate(translations))
+    }
+}
+
+TranslateContent().main(args)

--- a/tools/kotlin/translate-content.main.kts
+++ b/tools/kotlin/translate-content.main.kts
@@ -16,7 +16,7 @@ import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
 import java.io.File
 
-val DEEPL_REQUEST_LIMIT = 1024 * 128
+val DEEPL_REQUEST_LIMIT = 1024 * 100
 
 class TranslateContent : CliktCommand(help = "Translate content file with DeepL") {
     private val contentFileOrRootDir: File by option("--content")

--- a/tools/kotlin/translate-content.main.kts
+++ b/tools/kotlin/translate-content.main.kts
@@ -40,12 +40,11 @@ class TranslateContent : CliktCommand(help = "Translate content file with DeepL"
                 }
         }
 
-        val options = DumperOptions().apply {
-            isExplicitStart = true
+        val dumperOptions = DumperOptions().apply {
             defaultFlowStyle = DumperOptions.FlowStyle.BLOCK
-            defaultScalarStyle = DumperOptions.ScalarStyle.PLAIN
+            isPrettyFlow = true
         }
-        val yaml = Yaml(options)
+        val yaml = Yaml(dumperOptions)
         // Call DeepL file by file to avoid multiple network calls
         filesToTranslate.forEach { file ->
             val parsedYaml = yaml.load<MutableMap<Any, Any>>(file.readText())
@@ -90,7 +89,7 @@ class TranslateContent : CliktCommand(help = "Translate content file with DeepL"
 }
 
 @Suppress("UNCHECKED_CAST")
-fun Map<Any, Any>.toScalarList(): List<String> = map { (key, value) ->
+fun Map<Any, Any>.toScalarList(): List<String> = map { (_, value) ->
     when (value) {
         is String -> listOf(value)
         is Map<*, *> -> (value as Map<Any, Any>).toScalarList()


### PR DESCRIPTION

**Description**

This PR adds a script to automate draft translations with DeepL. 

Unfortunately, I'm not fluent in python, so add the script in Kotlin. 
The script is not a product of precise specification but a weekend hack of things I need to know. So script code could be refactored to a more readable and maintainable structure.
I'm also new to DeepL API. I can probably format text to XML, JSON, or DeepL has another solution to preserve keys.

The script has two bugs:
1. It Doesn't run for big files since DeepL has a limit on the request size, and I didn't come up with an easy translation split that will not break the `key` to `value` structure
2. The format of the string 

**Related to** #2031

Manual translating is slow and exousting. Feeding content to this script leaves only tiny corrections left to the translator.

**How to test**

* Read README in the script folder to setup the environment
* Run script 
```
./tools/kotlin/translate-content.main.kts --content content --language <language to translate> --deepl-key <deepl-key>
```

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion 
- [x] Has a "How to test" section
- [ ] Runs well on the files that content for translation is bigger than the DeepL limit
- [ ] Fix a bug when DeepL changes int to a different int in translation
- [x] The Ukrainian translation is reviewed by a native speaker (me)

