### PR TITLE
[FEAT] UI: focus language input on opening dropdown

### DIFF
--- a/templates/incl/menubar.html
+++ b/templates/incl/menubar.html
@@ -41,7 +41,7 @@
       <!-- Not logged in -->
       <li class="menubar-item dropdown relative z-20">
           {# Needs a 'block' because it contains a flexbox child #}
-          <a class="menubar-text block border-transparent cursor-pointer" onclick="$('.dropdown-menu').hide();$('#language-dropdown').slideToggle('medium');" data-cy="language-dropdown">
+          <a class="menubar-text block border-transparent cursor-pointer" onclick="$('.dropdown-menu').hide();$('#language-dropdown').slideToggle('medium'); $('#search_language').focus();" data-cy="language-dropdown">
             <div class="flex flex-row gap-2 items-center">
                 <i class="fas fa-fw fa-globe"></i>
                 <span class="hidden lg:flex">{{ current_language().sym }}</span>


### PR DESCRIPTION
If you are looking for a language, you previously needed to click the language dropdown, then the input, and only then could you start typing.

Focus the language input immediately on opening the dropdown so you can start typing right away.

**How to test**

Click the Language dropdown, start typing.