### PR TITLE
[UI IMPROVEMENT] Smoothen dropdown menus

### DIFF
--- a/templates/incl/menubar.html
+++ b/templates/incl/menubar.html
@@ -22,7 +22,7 @@
             </a>
         </li>
         <li class="flex-initial menubar-item dropdown relative z-20{% if current_page == 'my-profile' %} active{% endif %}">
-            <a class="menubar-text cursor-pointer whitespace-nowrap" onclick="$('.dropdown-menu').hide(); $('#profile-dropdown').slideToggle('medium');">
+            <a class="menubar-text cursor-pointer whitespace-nowrap" onclick="$('#profile-dropdown').slideToggle('medium');">
                 {% if session.profile_image %}
                     <img src="{{static('/images/profile_images/' + session.profile_image + '.png')}}" class="h-8 lg:h-10 inline-block">
                 {% else %}
@@ -41,7 +41,7 @@
       <!-- Not logged in -->
       <li class="menubar-item dropdown relative z-20">
           {# Needs a 'block' because it contains a flexbox child #}
-          <a class="menubar-text block border-transparent cursor-pointer" onclick="$('.dropdown-menu').hide();$('#language-dropdown').slideToggle('medium'); $('#search_language').focus();" data-cy="language-dropdown">
+          <a class="menubar-text block border-transparent cursor-pointer" onclick="$('#language-dropdown').slideToggle('medium'); $('#search_language').focus();" data-cy="language-dropdown">
             <div class="flex flex-row gap-2 items-center">
                 <i class="fas fa-fw fa-globe"></i>
                 <span class="hidden lg:flex">{{ current_language().sym }}</span>

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -17,7 +17,7 @@
       {% endif %}
       {% if not hide_cheatsheet and cheatsheet %}
         <div class="dropdown relative">
-              <button class="green-btn font-semibold rounded inline-flex items-center gap-2" id="dropdown_cheatsheet_button" onclick="$('.dropdown-menu').hide();$('#cheatsheet_dropdown').slideToggle('medium');">
+              <button class="green-btn font-semibold rounded inline-flex items-center gap-2" id="dropdown_cheatsheet_button" onclick="$('#cheatsheet_dropdown').slideToggle('medium');">
                   <span>{{ "🤔" }}</span>
                   <svg class="fill-current h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/> </svg>
               </button>
@@ -41,7 +41,7 @@
     {% endif %}
     {% if get_syntax_language(g.lang) != "en" and (not customizations or 'hide_keyword_switcher' not in customizations['other_settings']) %}
       <div class="dropdown relative">
-          <button class="green-btn font-semibold rounded inline-flex items-center gap-2" onclick="$('.dropdown-menu').hide();$('#commands_dropdown').slideToggle('medium');" data-cy="kwlang-switch-btn">
+          <button class="green-btn font-semibold rounded inline-flex items-center gap-2" onclick="$('#commands_dropdown').slideToggle('medium');" data-cy="kwlang-switch-btn">
                   <span class="fa-solid fa-language"></span>
                   <svg class="fill-current h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/> </svg>
           </button>


### PR DESCRIPTION
**Description**
Slide toggle hide a dropdown when the button is pressed again instead of the hacky re-slide open we currently have.

**Fixes**
This PR fixes #4066

**How to test**
Verify that the language dropdown, user profile dropdown and both the cheatsheet and language switcher dropdown all close when the button is pressed again. This makes the animation a lot more smooth than what currently happens when we press the button twice.
