### PR TITLE
[CHORE] Update snippets hashes after merge

### DIFF
--- a/.github/workflows/generate-snippet-hashes.yml
+++ b/.github/workflows/generate-snippet-hashes.yml
@@ -1,11 +1,13 @@
 env:
   save_snippet_hashes: True
 
-name: Periodically generate hashes
+name: Update hashes
 on:
-  schedule:
-    - cron: "0 3 * * 1-5" # Run this job every workday at 3am
-  workflow_dispatch: {} # Allow running the workflow on-demand
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  
 jobs:
   build:
 
@@ -47,9 +49,10 @@ jobs:
         
     - name: Commit changed files
       uses: stefanzweifel/git-auto-commit-action@v2.3.0
+      if: github.event_name == 'push'
       with:
         commit_message: Updating hash files
-        branch: main
+        branch: ${{ github.ref_name }}
       env:
         # This is necessary to bypass branch protection (which will disallow non-reviewed pushes otherwise)
         GITHUB_TOKEN: ${{ secrets.FELIENNE_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Why not run the snippet updater on any PR, that is better than randomly every day. Main reason that I don't like is is that I get "github activity points" every day, we could also swap out my token for another one? But this is a solution too.

I have not merged this because I can't oversee having two actions with the same trigger (on a PR merge) and I fear this might lead to annoying things like the two actions keeping the branch outdated or something. Maybe we should merge them into one? 

Maybe @rix0rrr knows what is best here? 