### PR TITLE
[LANG] Allow assigning to a list element by index

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -5,9 +5,9 @@ assign_list: var (_IS| _EQUALS) (text_in_quotes|NUMBER) (_COMMA (text_in_quotes|
 ?atom: NUMBER | _MINUS NUMBER | var_access | text_in_quotes //unsupported numbers are gone, we can now allow floats with NUMBER
 ?print_expression: var_access_print | error_unsupported_number | NUMBER
 
-equality_check: (var_access | text_in_quotes | NUMBER) (_IS| _EQUALS) (var_access | text_in_quotes | NUMBER)
+equality_check: (list_access | var_access | text_in_quotes | NUMBER) (_IS| _EQUALS) (list_access | var_access | text_in_quotes | NUMBER)
 
-in_list_check: (var_access | text_in_quotes | NUMBER) _IN var_access
+in_list_check: (list_access | var_access | text_in_quotes | NUMBER) _IN var_access
 
 // all literal strings have to be quoted now, so arithmetic operators don't need to be excluded anymore
 text_with_spaces_without_single_quotes: /(?:[^\n،,' ]| (?!else|başka|अन्यथा|否则|ellers|anders|sinon|sino|وإلا))+/ -> text

--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -1,5 +1,5 @@
 //assigning a string now must be done with quotes
-assign: var (_IS| _EQUALS) (list_access | atom | expression)
+assign: (list_access | var) (_IS| _EQUALS) (list_access | atom | expression)
 assign_list: var (_IS| _EQUALS) (text_in_quotes|NUMBER) (_COMMA (text_in_quotes|NUMBER))+
 
 ?atom: NUMBER | _MINUS NUMBER | var_access | text_in_quotes //unsupported numbers are gone, we can now allow floats with NUMBER

--- a/grammars/level14-Additions.lark
+++ b/grammars/level14-Additions.lark
@@ -10,4 +10,4 @@ smaller_equal: comparison_arg  _SMALLER_EQUALS  comparison_arg
 bigger_equal: comparison_arg  _LARGER_EQUALS  comparison_arg
 not_equal: comparison_arg  _NOT_EQUALS  comparison_arg
 
-?comparison_arg: var_access | text_in_quotes | NUMBER
+?comparison_arg: var_access | list_access | text_in_quotes | NUMBER

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -358,7 +358,6 @@ class TestsLevel12(HedyTester):
         player = 'x'
         choice = 1
         field = '.', '.', '.', '.', '.', '.', '.', '.', '.'
-        
         if field at choice = '.'
             field at choice = player
         else

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -353,6 +353,28 @@ class TestsLevel12(HedyTester):
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
+    def test_if_and_list_access(self):
+        code = textwrap.dedent("""\
+        player = 'x'
+        choice = 1
+        field = '.', '.', '.', '.', '.', '.', '.', '.', '.'
+        
+        if field at choice = '.'
+            field at choice = player
+        else
+            print 'illegal move!'""")
+
+        expected = textwrap.dedent("""\
+        player = 'x'
+        choice = 1
+        field = ['.', '.', '.', '.', '.', '.', '.', '.', '.']
+        if convert_numerals('Latin', field[int(choice)-1]) == convert_numerals('Latin', '.'):
+          field[int(choice)-1] = player
+        else:
+          print(f'''illegal move!''')""")
+
+        self.multi_level_tester(code=code, expected=expected, max_level=15)
+
     def test_print_calc(self):
         code = textwrap.dedent("""\
             var is 5

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -336,6 +336,23 @@ class TestsLevel12(HedyTester):
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
+    def test_assign_to_list_access(self):
+        code = textwrap.dedent("""\
+            field = '.', '.', '.', '.', '.', '.'
+            field at 1 = 'x'
+            print field at 1""")
+
+        expected = textwrap.dedent("""\
+            field = ['.', '.', '.', '.', '.', '.']
+            field[int(1)-1] = 'x'
+            try:
+              field[int(1)-1]
+            except IndexError:
+              raise Exception('catch_index_exception')
+            print(f'''{field[int(1)-1]}''')""")
+
+        self.multi_level_tester(code=code, expected=expected, max_level=15)
+
     def test_print_calc(self):
         code = textwrap.dedent("""\
             var is 5


### PR DESCRIPTION
Fixes #4103 and fixes #4103

We might want to either disallow or fix this though, as it seems like reasonable thing that could work:

```
bord = '.', '.', '.', '.', '.', '.', '.', '.', '.'
bord at random = 'x'
```

![image](https://user-images.githubusercontent.com/1003685/224285745-ee99fa54-e508-48ac-851b-b4e8a7c11c93.png)

