### PR TITLE
Fix kurdish translations

### DIFF
--- a/hedy_content.py
+++ b/hedy_content.py
@@ -20,9 +20,9 @@ ALL_KEYWORD_LANGUAGES = {}
 NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'pa_PK', 'ru', 'zh_Hans']
 
 # Babel has a different naming convention than Weblate and doesn't support some languages -> fix this manually
-CUSTOM_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK', 'tn': 'en', 'tl': 'en'}
+CUSTOM_BABEL_LANGUAGES = {'pa_PK': 'pa_Arab_PK', 'kmr': 'ku_TR', 'tn': 'en', 'tl': 'en'}
 # For the non-existing language manually overwrite the display language to make sure it is displayed correctly
-CUSTOM_LANGUAGE_TRANSLATIONS = {'tn': 'Setswana', 'tl': 'ᜆᜄᜎᜓᜄ᜔'}
+CUSTOM_LANGUAGE_TRANSLATIONS = {'kmr': 'Kurdî (Tirkiye)', 'tn': 'Setswana', 'tl': 'ᜆᜄᜎᜓᜄ᜔'}
 customize_babel_locale(CUSTOM_BABEL_LANGUAGES)
 
 ADVENTURE_NAMES = [


### PR DESCRIPTION
**Description**
Fixing the language gap between weblate and babel by manually overwriting the Kurdish language key.

**Fixes**
This PR fixes #4119

**How to test**
Check that no placeholders are shown for Kurdish.
