### PR TITLE
[FIX] Improve logout experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ from website import (ab_proxying, achievements, admin, auth_pages, aws_helpers,
                      profile, programs, querylog, quiz, statistics,
                      translating)
 from website.auth import (current_user, is_admin, is_teacher,
-                          login_user_from_token_cookie, requires_login, requires_teacher)
+                          login_user_from_token_cookie, requires_login, requires_login_redirect, requires_teacher)
 from website.log_fetcher import log_fetcher
 from website.types import Adventure, Program, ExtraStory, SaveInfo
 
@@ -836,7 +836,7 @@ def achievements_page():
 
 
 @app.route('/programs', methods=['GET'])
-@requires_login
+@requires_login_redirect
 def programs_page(user):
     username = user['username']
     if not username:
@@ -1429,7 +1429,7 @@ def reset_page():
 
 
 @app.route('/my-profile', methods=['GET'])
-@requires_login
+@requires_login_redirect
 def profile_page(user):
     profile = DATABASE.user_by_username(user['username'])
     programs = DATABASE.public_programs_for_user(user['username'])

--- a/utils.py
+++ b/utils.py
@@ -275,7 +275,7 @@ def error_page(error=404, page_error=None, ui_message=None, menu=True, iframe=No
     elif error == 500:
         default = gettext('default_500')
 
-    if request.accept_mimetypes.accept_json:
+    if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         # Produce a JSON response instead of an HTML response
         return jsonify({"code": error, "error": default}), error
 

--- a/website/auth.py
+++ b/website/auth.py
@@ -10,7 +10,7 @@ import boto3
 import requests
 from botocore.exceptions import ClientError as email_error
 from botocore.exceptions import NoCredentialsError
-from flask import g, request, session
+from flask import g, request, session, redirect
 from flask_babel import force_locale, gettext
 
 import utils
@@ -194,6 +194,23 @@ def requires_login(f):
 
     return inner
 
+
+def requires_login_redirect(f):
+    """Decoractor to indicate that a particular route requires the user to be logged in.
+
+    If the user is not logged in, they will be redirected to the front page.
+    """
+
+    @wraps(f)
+    def inner(*args, **kws):
+        if not is_user_logged_in():
+            return redirect('/')
+        # The reason we pass by keyword argument is to make this
+        # work logically both for free-floating functions as well
+        # as [unbound] class methods.
+        return f(*args, user=current_user(), **kws)
+
+    return inner
 
 def requires_admin(f):
     """Similar to 'requires_login', but also tests that the user is an admin.

--- a/website/profile.py
+++ b/website/profile.py
@@ -18,7 +18,6 @@ from website.auth import (
     password_hash,
     remember_current_user,
     requires_login,
-    requires_login_redirect,
     send_email_template,
 )
 

--- a/website/profile.py
+++ b/website/profile.py
@@ -18,6 +18,7 @@ from website.auth import (
     password_hash,
     remember_current_user,
     requires_login,
+    requires_login_redirect,
     send_email_template,
 )
 
@@ -139,8 +140,8 @@ class ProfileModule(WebsiteModule):
         remember_current_user(self.db.user_by_username(user["username"]))
         return jsonify(resp)
 
-    @ route("/", methods=["GET"])
-    @ requires_login
+    @route("/", methods=["GET"])
+    @requires_login
     def get_profile(self, user):
         # The user object we got from 'requires_login' is not fully hydrated yet. Look up the database user.
         user = self.db.user_by_username(user["username"])


### PR DESCRIPTION
Previously, when you log out, you would be shown a JSON error message (because the browser will send `Accept: */*`, which includes JSON, and that's what we feature tested for). The goal was to respond with JSON to the Ajax requests. Fix by feature testing for yes JSON, but not HTML.

Also, the previous PR made it so that if you log out, you stay on the same page. But if this page is now a "my profile" page or "programs" page, it shows you a very big unfriendly "you are not logged in message".

Add a new `@requires_login_redirect` decorator, which redirects you back to the front page if you end up not logged in on certain pages.

**How to test**

Log in, go to your profile page, then log out. You end up back at the front page.