### PR TITLE
[FIX] Handle incomplete database rows

### DIFF
--- a/website/types.py
+++ b/website/types.py
@@ -39,12 +39,13 @@ class Program:
 
     @staticmethod
     def from_database_row(r):
+        """Convert a database row into a typed Program object."""
         return Program(
-            name=r['name'],
-            code=r['code'],
-            date=r['date'],
+            name=r.get('name', ''),
+            code=r.get('code', ''),
+            date=r.get('date', 0),
             adventure_name=r.get('adventure_name', 'default'),
-            id=r.get('id'),
+            id=r.get('id', ''),
             public=r.get('public'),
             submitted=r.get('submitted'))
 


### PR DESCRIPTION
Not all database rows have all columns they should have. The current code that was dealing with database rows was assuming they did.

Remove that assumption, change `r['name']` into `r.get('name', '')` so that the code doesn't throw.

Fixes #4153.

**How to test**

It's not clear how to reproduce this, it depends heavily on what's in the database.