### PR TITLE
[FIX] Student needs to wait 5m or logout after joining class

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -94,9 +94,10 @@ def password_hash(password, salt):
 # You can remove the current user from the Flask session with the `forget_current_user`.
 def remember_current_user(db_user):
     session["user-ttl"] = times() + 5 * 60
-    session["user"] = pick(db_user, "username", "email", "is_teacher", "classes")
+    session["user"] = pick(db_user, "username", "email", "is_teacher")
     session["lang"] = db_user.get("language", "en")
     session["keyword_lang"] = db_user.get("keyword_language", "en")
+    session["classes"] = db_user.get("classes") or set()
 
 
 def pick(d, *requested_keys):
@@ -118,17 +119,23 @@ def force_json_serializable_type(x):
 # If the current user is too old, as determined by the time-to-live, we repopulate from the database.
 def current_user():
     now = times()
-    user = session.get("user", {"username": "", "email": ""})
     ttl = session.get("user-ttl", None)
     if ttl is None or now >= ttl:
-        username = user["username"]
-        if username:
-            db_user = g.db.user_by_username(username)
-            if not db_user:
-                raise RuntimeError(f"Cannot find current user in db anymore: {username}")
-            remember_current_user(db_user)
+        refresh_current_user_from_db()
 
+    user = session.get("user", {"username": "", "email": ""})
     return user
+
+
+def refresh_current_user_from_db():
+    """Refresh the cached session data for the current user from the database."""
+    user = session.get("user", {"username": "", "email": ""})
+    username = user["username"]
+    if username:
+        db_user = g.db.user_by_username(username)
+        if not db_user:
+            raise RuntimeError(f"Cannot find current user in db anymore: {username}")
+        remember_current_user(db_user)
 
 
 def is_user_logged_in():

--- a/website/classes.py
+++ b/website/classes.py
@@ -6,7 +6,7 @@ from flask_babel import gettext
 import utils
 from config import config
 from website.flask_helpers import render_template
-from website.auth import current_user, is_teacher, requires_login, requires_teacher
+from website.auth import current_user, is_teacher, requires_login, requires_teacher, refresh_current_user_from_db
 
 from .achievements import Achievements
 from .database import Database
@@ -134,6 +134,7 @@ class ClassModule(WebsiteModule):
             return gettext("join_prompt"), 403
 
         self.db.add_student_to_class(Class["id"], current_user()["username"])
+        refresh_current_user_from_db()
         # We only want to remove the invite if the user joins the class with an actual pending invite
         invite = self.db.get_username_invite(current_user()["username"])
         if invite and invite.get("class_id") == body["id"]:
@@ -154,6 +155,7 @@ class ClassModule(WebsiteModule):
             return gettext("ajax_error"), 400
 
         self.db.remove_student_from_class(Class["id"], student_id)
+        refresh_current_user_from_db()
         achievement = None
         if Class["teacher"] == user["username"]:
             achievement = self.achievements.add_single_achievement(user["username"], "detention")


### PR DESCRIPTION
The classes that a student is part of is cached on their session (so we don't have to query the database on every page load).

However, we failed to refresh the cache when the user joins a class. The result was that they had to wait 5 minutes for their session data to be refreshed as usual, or log out and back in to force a refresh.

Instead, do the refresh on joining and leaving a class.

Thanks for catching this @TiBiBa!

**How to test**

Invite a new student that's not in any classes. Join as that student, observe that you can submit programs immediately (instead of after 5 minutes)

(Fixing a bug mentioned in #4156)