### PR TITLE
[UI] Translate tooltips for new buttons

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -623,7 +623,7 @@ msgstr ""
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 msgid "heard_about_hedy"

--- a/templates/incl/hand-in-modal.html
+++ b/templates/incl/hand-in-modal.html
@@ -2,7 +2,7 @@
   <div class="absolute bg-black w-full h-full opacity-75" onclick="hedyApp.closeContainingModal(this)"></div>
   <div class="absolute flex justify-center w-full h-full">
     <div class="relative w-full max-w-xl bg-white border-2 border-blue-400 rounded-lg p-8 shadow-xl h-min mt-24">
-      <h2>{{_('hand_in_assignment')}}</h2>
+      <h2>{{_('hand_in_exercise')}}</h2>
 
       {% if username and current_user_is_in_class %}
 

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -12,10 +12,10 @@
     <div class="flex-1">
       <div id="program_name_container" class="flex-1 flex border border-blue-400 ltr:divide-x rtl:divide-x-reverse divide-blue-400 rounded md:mx-16 items-center">
         <input id="program_name" type="text" class="outline-0 text-2xl font-light text-blue-500 flex-1 bg-transparent focus:bg-blue-100 border-0 px-4 flex-1 h-full py-1" value="{{initial_adventure.save_name}}">
-        <button id="share_program_button" class="h-full" title="Share your program">
+        <button id="share_program_button" class="h-full" title="{{_('share_your_program')}}">
           <span class="fa-solid fa-arrow-up-from-bracket text-2xl p-2 px-4 w-14 text-blue-500"></span>
         </button>
-        <button id="hand_in_button" class="h-full" title="Hand in your assignment">
+        <button id="hand_in_button" class="h-full" title="{{_('hand_in_assignment')}}">
           <span class="fa-regular fa-paper-plane text-2xl p-2 px-4 w-14 text-blue-500"></span>
         </button>
       </div>

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -15,7 +15,7 @@
         <button id="share_program_button" class="h-full" title="{{_('share_your_program')}}">
           <span class="fa-solid fa-arrow-up-from-bracket text-2xl p-2 px-4 w-14 text-blue-500"></span>
         </button>
-        <button id="hand_in_button" class="h-full" title="{{_('hand_in_assignment')}}">
+        <button id="hand_in_button" class="h-full" title="{{_('hand_in_exercise')}}">
           <span class="fa-regular fa-paper-plane text-2xl p-2 px-4 w-14 text-blue-500"></span>
         </button>
       </div>

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -672,7 +672,7 @@ msgstr "الذهاب الى ملفي الشخصي"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -785,7 +785,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -818,7 +818,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -792,7 +792,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -784,7 +784,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -620,7 +620,7 @@ msgstr "Mein Profil"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 msgid "heard_about_hedy"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -697,7 +697,7 @@ msgstr "Πήγαινε στο προφίλ μου"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -624,8 +624,8 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr "Hand in"
 
-msgid "hand_in_assignment"
-msgstr "Hand in assignment"
+msgid "hand_in_exercise"
+msgstr "Hand in exercise"
 
 msgid "heard_about_hedy"
 msgstr "How have you heard about Hedy?"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -721,7 +721,7 @@ msgstr "Al mia profilo"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -620,7 +620,7 @@ msgstr "Ir a mi perfil"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 msgid "heard_about_hedy"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -801,7 +801,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -816,7 +816,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -659,7 +659,7 @@ msgstr "Aller à mon profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -772,7 +772,7 @@ msgstr "Nei myn profyl"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -790,7 +790,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -703,7 +703,7 @@ msgstr "मेरी प्रोफ़ाइल पर जाएँ"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -774,7 +774,7 @@ msgstr "A profilomhoz"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -773,7 +773,7 @@ msgstr "Ke profil saya"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -786,7 +786,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -821,7 +821,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -822,7 +822,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -686,7 +686,7 @@ msgstr "Gå til min profil"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -641,7 +641,7 @@ msgstr "Ga naar mijn profiel"
 msgid "hand_in"
 msgstr "Inleveren"
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr "Opdracht inleveren"
 
 #, fuzzy

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -822,7 +822,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -621,7 +621,7 @@ msgstr "Idź do mój profil"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 msgid "heard_about_hedy"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -775,7 +775,7 @@ msgstr "Ir para meu perfil"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -782,7 +782,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -753,7 +753,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -818,7 +818,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -788,7 +788,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -821,7 +821,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -815,7 +815,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -757,7 +757,7 @@ msgstr "Перейти до мого профілю"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -684,7 +684,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -823,7 +823,7 @@ msgstr "Go to my profile"
 msgid "hand_in"
 msgstr ""
 
-msgid "hand_in_assignment"
+msgid "hand_in_exercise"
 msgstr ""
 
 #, fuzzy


### PR DESCRIPTION
The tooltips for the new "share" and "hand in" buttons were accidentally not translated. Translate them as well.

**How to test**

Pick Dutch. Hover over the new buttons next to the program name.