### PR TITLE
[FIX] Survive another missing program name

### DIFF
--- a/app.py
+++ b/app.py
@@ -1380,7 +1380,7 @@ def not_found(exception):
 def internal_error(exception):
     import traceback
     print(traceback.format_exc())
-    return utils.error_page(error=500)
+    return utils.error_page(error=500, exception=exception)
 
 
 @app.route('/signup', methods=['GET'])

--- a/utils.py
+++ b/utils.py
@@ -11,6 +11,7 @@ import string
 import random
 import uuid
 import unicodedata
+import traceback
 
 from flask_babel import gettext, format_date, format_datetime, format_timedelta
 from ruamel import yaml
@@ -266,7 +267,7 @@ def markdown_to_html_tags(markdown):
     return soup.find_all()
 
 
-def error_page(error=404, page_error=None, ui_message=None, menu=True, iframe=None):
+def error_page(error=404, page_error=None, ui_message=None, menu=True, iframe=None, exception=None):
     if error not in [403, 404, 500]:
         error = 404
     default = gettext('default_404')
@@ -277,7 +278,7 @@ def error_page(error=404, page_error=None, ui_message=None, menu=True, iframe=No
 
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         # Produce a JSON response instead of an HTML response
-        return jsonify({"code": error, "error": default}), error
+        return jsonify({"code": error, "error": default, "exception": traceback.format_exception(exception) if exception else None }), error
 
     return render_template("error-page.html", menu=menu, error=error, iframe=iframe,
                            page_error=page_error or ui_message or '', default=default), error

--- a/website/programs.py
+++ b/website/programs.py
@@ -169,13 +169,11 @@ class ProgramsModule(WebsiteModule):
         # We don't NEED to pass this in, but it saves the database a lookup if we do.
         program_public = body.get("shared")
 
-        print('A', program_public)
-
         if not program_id:
             # Legacy save mode: overwrite a program with the same name if it already exists
             # (Not sure when this is used)
             for program in self.db.programs_for_user(user["username"]):
-                if program["name"] == body["name"]:
+                if program.get("name", '') == body["name"]:
                     program_id = program["id"]
                     if program_public is None:
                         program_public = program.get("public", False)


### PR DESCRIPTION
Similar to #4158, there was another place where we were assuming that all programs have a `name` field, which is not true in the actual database.

A couple more fixes around error reporting:

- The `Accept` header may not contain charsets in the MIME type, so remove them. This caused the content negotation to not work, and the error page to still render HTML.
- When we are rendering the error as JSON, include the exception message. This will be good for technical debugging, and make it so we may not have to go into the server logs to find exceptions.
- Get an appropriate error message out of the server response.

**How to test**

Log in to alpha, switch between private and public.