### PR TITLE
[FIX] Return newest state of record on update

### DIFF
--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -533,7 +533,7 @@ class AwsDynamoStorage(TableStorage):
         value_updates = {k: v for k, v in updates.items() if not isinstance(v, DynamoUpdate)}
         special_updates = {k: v.to_dynamo() for k, v in updates.items() if isinstance(v, DynamoUpdate)}
 
-        return self.db.update_item(
+        response = self.db.update_item(
             TableName=make_table_name(self.db_prefix, table_name),
             Key=self._encode(key),
             AttributeUpdates={
@@ -543,6 +543,7 @@ class AwsDynamoStorage(TableStorage):
             # Return the full new item after update
             ReturnValues='ALL_NEW',
         )
+        return self._decode(response.get('Attributes', {}))
 
     def delete(self, table_name, key):
         return self.db.delete_item(TableName=make_table_name(self.db_prefix, table_name), Key=self._encode(key))

--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -41,9 +41,17 @@ class TableStorage(metaclass=ABCMeta):
         ...
 
     def put(self, table_name, key, data):
+        """Put the given data under the given key.
+
+        Does not need to return anything.
+        """
         ...
 
     def update(self, table_name, key, updates):
+        """Update the given record, identified by a key, with updates.
+
+        Must return the updated state of the record.
+        """
         ...
 
     def delete(self, table_name, key):
@@ -270,6 +278,7 @@ class Table:
 
         querylog.log_counter(f"db_create:{self.table_name}")
         self.storage.put(self.table_name, self._extract_key(data), data)
+        return data
 
     def put(self, data):
         """An alias for 'create', if calling create reads uncomfortably."""
@@ -518,7 +527,7 @@ class AwsDynamoStorage(TableStorage):
         return key_expression, attr_values, attr_names
 
     def put(self, table_name, _key, data):
-        return self.db.put_item(TableName=make_table_name(self.db_prefix, table_name), Item=self._encode(data))
+        self.db.put_item(TableName=make_table_name(self.db_prefix, table_name), Item=self._encode(data))
 
     def update(self, table_name, key, updates):
         value_updates = {k: v for k, v in updates.items() if not isinstance(v, DynamoUpdate)}
@@ -531,6 +540,8 @@ class AwsDynamoStorage(TableStorage):
                 **self._encode_updates(value_updates),
                 **special_updates,
             },
+            # Return the full new item after update
+            ReturnValues='ALL_NEW',
         )
 
     def delete(self, table_name, key):


### PR DESCRIPTION
The new program storing logic was assuming that `update` would return the updated state of the record.

This is an option in DynamoDB, but it is not the default.

Switch it on.

**How to test**

(can only be tested on alpha) Sharing a program will no longer throw an error.