### PR TITLE
[FIX] Remove unnecessary saves, load from local storage even if logged in

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -6,7 +6,7 @@ import JSZip from "jszip";
 import { Tabs } from './tabs';
 import { MessageKey } from './message-translations';
 import { turtle_prefix, pygame_prefix, normal_prefix } from './pythonPrefixes'
-import { Achievement, Adventure } from './types';
+import { Achievement, Adventure, isServerSaveInfo, ServerSaveInfo } from './types';
 import { startIntroTutorial } from './tutorials/tutorial';
 import { loadParsonsExercise } from './parsons';
 import { checkNow, onElementBecomesVisible } from './browser-helpers/on-element-becomes-visible';
@@ -196,13 +196,12 @@ export function initializeCodePage(options: InitializeCodePageOptions) {
     currentTab = ev.newTab;
     const adventure = theAdventures[currentTab];
 
-    if (!theUserIsLoggedIn) {
-      // Load initial code from local storage, if available
-      const programFromLs = localLoad(currentTabLsKey());
-      if (programFromLs && adventure) {
-        adventure.start_code = programFromLs.code;
-        adventure.save_name = programFromLs.saveName;
-      }
+    // Load initial code from local storage, if available
+    const programFromLs = localLoad(currentTabLsKey());
+    if (programFromLs && adventure) {
+      adventure.start_code = programFromLs.code;
+      adventure.save_name = programFromLs.saveName;
+      adventure.save_info = 'local-storage';
     }
 
     reconfigurePageBasedOnTab();
@@ -539,7 +538,7 @@ export async function runit(level: number, lang: string, disabled_prompt: string
         adventure_name: adventureName,
 
         // Save under an existing id if this field is set
-        program_id: adventure?.save_info?.id,
+        program_id: isServerSaveInfo(adventure?.save_info) ? adventure.save_info.id : undefined,
         save_name: saveNameFromInput(),
       });
 
@@ -1802,20 +1801,24 @@ function updatePageElements() {
 
   const adventure = theAdventures[currentTab];
   if (adventure) {
+    const saveInfo: ServerSaveInfo = isServerSaveInfo(adventure.save_info)
+      ? adventure.save_info
+      : { id : '*dummy*' };
+
     // SHARING SETTINGS
     // Star on "share" button is filled if program is already public, outlined otherwise
-    const isPublic = !!adventure.save_info?.public;
+    const isPublic = !!saveInfo.public;
     $('#share_program_button')
       .toggleClass('active-bluebar-btn', isPublic);
     $(`#share-${isPublic ? 'public' : 'private'}`).prop('checked', true);
 
     // Show <...data-view="if-public-url"> only if we have a public url
-    $('[data-view="if-public"]').toggle(!!adventure.save_info?.public);
-    $('[data-view="if-public-url"]').toggle(!!adventure.save_info?.public_url);
-    $('input[data-view="public-url"]').val(adventure.save_info?.public_url ?? '');
+    $('[data-view="if-public"]').toggle(isPublic);
+    $('[data-view="if-public-url"]').toggle(!!saveInfo.public_url);
+    $('input[data-view="public-url"]').val(saveInfo.public_url ?? '');
 
     // Paper plane on "hand in" button is filled if program is already submitted, outlined otherwise
-    const isSubmitted = !!adventure.save_info?.submitted;
+    const isSubmitted = !!saveInfo.submitted;
     $('#hand_in_button')
       .toggleClass('active-bluebar-btn', isSubmitted);
 
@@ -1864,12 +1867,12 @@ function initializeShareProgramButtons() {
       const isPublic = $(ev.target).val() === '1' ? true : false;
 
       // Async-safe copy of current tab
-      const adventureName = currentTab;
+      const adventure = theAdventures[currentTab];
 
       tryCatchPopup(async () => {
         await saveIfNecessary();
 
-        const saveInfo = theAdventures[adventureName]?.save_info;
+        const saveInfo = isServerSaveInfo(adventure?.save_info) ? adventure?.save_info : undefined;
         if (!saveInfo) {
           throw new Error('This program does not have an id');
         }
@@ -1881,7 +1884,7 @@ function initializeShareProgramButtons() {
 
         modal.notifySuccess(response.message);
         if (response.save_info) {
-          (theAdventures[adventureName] ?? {}).save_info = response.save_info;
+          adventure.save_info = response.save_info;
         }
         updatePageElements();
       });
@@ -1892,12 +1895,12 @@ function initializeShareProgramButtons() {
 function initializeHandInButton() {
   $('#do_hand_in_button').on('click', () => {
       // Async-safe copy of current tab
-      const adventureName = currentTab;
+      const adventure = theAdventures[currentTab];
 
       tryCatchPopup(async () => {
         await saveIfNecessary();
 
-        const saveInfo = theAdventures[adventureName]?.save_info;
+        const saveInfo = isServerSaveInfo(adventure?.save_info) ? adventure.save_info : undefined;
         if (!saveInfo) {
           throw new Error('This program does not have an id');
         }
@@ -1907,7 +1910,7 @@ function initializeHandInButton() {
 
         modal.notifySuccess(response.message);
         if (response.save_info) {
-          (theAdventures[adventureName] ?? {}).save_info = response.save_info;
+          adventure.save_info = response.save_info;
         }
         updatePageElements();
       });
@@ -1939,12 +1942,15 @@ function programNeedsSaving(adventureName: string) {
     return false;
   }
 
-  // We need to save if the content changed, OR if we are logged in but
-  // the program doesn't have an ID yet. Submitted programs are never saved again.
+  // We need to save if the content changed, OR if we have the opportunity to
+  // save a program that was loaded from local storage to the server.
+  // (Submitted programs are never saved again).
   const programChanged = theGlobalEditor.getValue() !== adventure.start_code;
   const nameChanged = $('#program_name').val() !== adventure.save_name;
-  const programWasNeverSavedBefore = theUserIsLoggedIn && !adventure.save_info?.id;
-  return (programChanged || nameChanged || programWasNeverSavedBefore) && !adventure.save_info?.submitted;
+  const localStorageCanBeSavedToServer = theUserIsLoggedIn && adventure.save_info === 'local-storage';
+  const isUnchangeable = isServerSaveInfo(adventure.save_info) ? adventure.save_info.submitted : false;
+
+  return (programChanged || nameChanged || localStorageCanBeSavedToServer) && !isUnchangeable;
 }
 
 /**
@@ -1977,15 +1983,16 @@ async function saveIfNecessary() {
   const saveName = saveNameFromInput();
 
   if (theUserIsLoggedIn) {
+    const saveInfo = isServerSaveInfo(adventure.save_info) ? adventure.save_info : undefined;
     const response = await postJsonWithAchievements('/programs', {
       level: theLevel,
       lang:  theLanguage,
       name:  saveName,
       code:  code,
       adventure_name: adventureName,
-      program_id: adventure.save_info?.id,
+      program_id: saveInfo?.id,
       // We pass 'public' in here to save the backend a lookup
-      share: adventure.save_info?.public,
+      share: saveInfo?.public,
     });
 
     // Record that we saved successfully

--- a/static/js/types.ts
+++ b/static/js/types.ts
@@ -37,11 +37,21 @@ export interface Adventure {
   /**
    * If the current program is from a save, some additional
    * information about the save.
+   *
+   * Either a ServerSaveInfo object if the program was loaded from a server save,
+   * or the string 'local-storage' if the program was loaded from local storage.
    */
-  save_info?: SaveInfo;
+  save_info?: ServerSaveInfo | 'local-storage';
 }
 
-export interface SaveInfo {
+/**
+ * Whether the given field is actually a SaveInfo object
+ */
+export function isServerSaveInfo(x: Adventure['save_info']): x is ServerSaveInfo {
+  return !!x && typeof x === 'object' && !!x.id;
+}
+
+export interface ServerSaveInfo {
   /** Identifier of the program in the database */
   id: string;
 


### PR DESCRIPTION
Fixing two bugs around local storage saving:

- In an attempt to account for saving local storage programs to the server, *every* program would be stored to the server, even if the student is just flipping through the tabs without actually changing the code.
- The code from local storage wouldn't even be loaded if the user is logged in -- which is besides the point, the point was that the code SHOULD be loaded if you are logged in, so that a program you wrote anonymously could still be saved to your account after login.

Solution:

- Check for local storage programs always.
- Keep track of whether a program is loaded from local storage, and save to the server only if it was in fact loaded from local storage.

**How to test**

(Regenerate JS locally, I did not check it in and the PR build doesn't rebuild it for some reason)

Take a new user. Open the network inspector of the browser. Tab through all adventures and observe that no new AJAX requests are sent.

Log out. Change a program. Log in again. Observe that your changed program is still visible. Keep the network inspector open, switch to a different tab (or wait a while). Observe that program program is saved.