### PR TITLE
[FIX] Do not overwrite programs with the same name

### DIFF
--- a/website/programs.py
+++ b/website/programs.py
@@ -169,16 +169,6 @@ class ProgramsModule(WebsiteModule):
         # We don't NEED to pass this in, but it saves the database a lookup if we do.
         program_public = body.get("shared")
 
-        if not program_id:
-            # Legacy save mode: overwrite a program with the same name if it already exists
-            # (Not sure when this is used)
-            for program in self.db.programs_for_user(user["username"]):
-                if program.get("name", '') == body["name"]:
-                    program_id = program["id"]
-                    if program_public is None:
-                        program_public = program.get("public", False)
-                    break
-
         if program_public:
             # If a program is marked as public, we need to know whether it contains
             # an error or not. Parse it here and add the status.


### PR DESCRIPTION
In the new autosave system, switching away from a tab automatically saves your current program.

Some students are experiencing that (for some reason we don't understand yet), their previous programs aren't automatically loaded, and then the autosave overwrites their old program with a blank one.

This can only happen because we have a legacy bit of code in there, which says that if you don't include a program id, it's going to overwrite an old program with the same name. Since no one ever changes the default save name, this is most likely the culprit of the old program being overwritten (new empty program has the same name as the old saved program, and is therefore clobbered).

Disable this behavior, as we don't need it any more and it in fact behaves poorly in combination with autosave. Either we loaded an old program and we overwrite it, or we didn't in which case we should always save in a new "slot".

**How to test**

Not sure how to reproduce this yet. If we had functionality to create a new program for the same combination of level+adventure that could be used to test this new behavior. For now... I can't think of a good way to test this.