### PR TITLE
[FIX] Restore loading old saved programs on teacher adventures

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,8 +171,13 @@ def load_saved_programs(level, into_adventures, preferential_program: Optional[P
         loaded_programs[preferential_program.adventure_name] = preferential_program
 
     # Copy them into the adventures array
+    #
+    # For every adventure, find a program in the `loaded_programs` dictionary.
+    # Since the program may be saved under either the id or the actual name, check both.
     for adventure in into_adventures:
         program = loaded_programs.get(adventure.short_name)
+        if not program:
+            program = loaded_programs.get(adventure.name)
         if not program:
             continue
 

--- a/website/database.py
+++ b/website/database.py
@@ -172,7 +172,7 @@ class Database:
         return [x for x in programs if x.get("level") == int(level)]
 
     def last_level_programs_for_user(self, username, level):
-        """List level programs for the given user, newest first.
+        """Return the most recent program for the given user at a given level.
 
         Returns: { adventure_name -> { code, name, ... } }
         """

--- a/website/types.py
+++ b/website/types.py
@@ -30,6 +30,13 @@ class Program:
     name: str
     code: str
     date: int
+
+    # The adventure name this program was written under
+    #
+    # - For built-in adventures, the short_name of the adventure
+    # - For teacher-written adventures:
+    #    - either the `id` of the teacher adventure (new); or
+    #    - the (display) `name` of the teacher adventure (old)
     adventure_name: str
     public: Optional[int] = None
     submitted: Optional[bool] = None


### PR DESCRIPTION
Programs are saved with the adventure they were associated with. For built-in adventures, this is the symbolic short name.  For teacher adventures, we used to store them with the long display name, but somewhere along the way this was changed to the adventure id.

The current code only uses the adventure id to select programs into a tab, but the result of that is that programs that were saved before the new standard cannot be loaded anymore.

Upon loading the student page, also identify programs by adventure name if no programs can be found by adventure id.

**How to test**

Find a student in a class with custom adventures that were saved before the attribute name was changed. Log in as that student, observe that the program is loaded onto the customer adventure tab.