### PR TITLE
[FIX] Parsons puzzles were not randomized

### DIFF
--- a/static/js/parsons.ts
+++ b/static/js/parsons.ts
@@ -103,9 +103,9 @@ function shuffle_code_lines(code: string) {
     let shuffled: Record<string, string> = {};
     let keys = Object.keys(code_lines);
     fisherYatesShuffle(keys);
-    for (const k of keys) {
-        shuffled[k] = code_lines[k];
-    }
+    keys.forEach((k, i) => {
+        shuffled[i] = code_lines[k];
+    });
     return shuffled;
 }
 


### PR DESCRIPTION
**Description**

The fisherYatesShuffle did it's work already; the shuffle_code_lines function returned an array with numeric keys, which was nicely shuffled, but retained the numeric sortorder, which was the correct order.

**Fixes #3475**

**How to test**

Go to any level, open the parsons tab, observe sort order; refresh and observe again.

**Checklist**
  
- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion 
- [x] Has a "How to test" section

