### PR TITLE
[FIX] Broken quiz preview

### DIFF
--- a/templates/preview-quiz.html
+++ b/templates/preview-quiz.html
@@ -2,6 +2,7 @@
 {% block regular_content %}
     {% include 'incl/quiz.html' %}
     <script>
+      // FIXME: Stop using inline JavaScript
       function ready(fn) {
         if (document.readyState !== 'loading'){
           fn();

--- a/templates/preview-quiz.html
+++ b/templates/preview-quiz.html
@@ -2,8 +2,15 @@
 {% block regular_content %}
     {% include 'incl/quiz.html' %}
     <script>
-        // FIXME: Stop using inline JavaScript
-      $(document).ready(function() {
+      function ready(fn) {
+        if (document.readyState !== 'loading'){
+          fn();
+        } else {
+          document.addEventListener('DOMContentLoaded', fn);
+        }
+      }
+
+      ready(function () {
         hedyApp.loadQuizQuestion({{ level }}, {{ question + 1 }});
       });
     </script>


### PR DESCRIPTION
**Description**

Wait for DOM to be loaded before loading quiz question.

**Fixes #4196 **

**How to test**

Going to the preview route (http://0.0.0.0:8080/quiz/preview-question/1/1) now gives the appropriate page.
