### PR TITLE
[TRANSLATION] Add Hungarian translations

### DIFF
--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -728,7 +728,7 @@ msgstr "Please select a valid gender, choose (Female, Male, Other)."
 
 #, fuzzy
 msgid "general"
-msgstr "Neme"
+msgstr "Általános"
 
 #, fuzzy
 msgid "general_settings"
@@ -744,11 +744,11 @@ msgstr "Get your certificate!"
 
 #, fuzzy
 msgid "give_link_to_teacher"
-msgstr "Give the following link to your teacher:"
+msgstr "Küldd el ezt a linket a tanárodnak:"
 
 #, fuzzy
 msgid "go_back_to_main"
-msgstr "Go back to main page"
+msgstr "Vissza a főoldalra"
 
 #, fuzzy
 msgid "go_to_first_question"
@@ -799,7 +799,7 @@ msgstr "Hedy on Github"
 
 #, fuzzy
 msgid "hedy_tutorial_logo_alt"
-msgstr "Start hedy tutorial"
+msgstr "Hedy bemutató indítása"
 
 msgid "hello_logo"
 msgstr "Helló!"
@@ -1248,7 +1248,7 @@ msgstr "Más szöveges programozási nyelv"
 
 #, fuzzy
 msgid "overwrite_warning"
-msgstr "You already have a program with this name, saving this program will overwrite the old one. Are you sure?"
+msgstr "Már van ilyen nevű programod, ami felül lesz írva, ha folytatod a mentést. Akarod folytatni?"
 
 #, fuzzy
 msgid "page"
@@ -1256,7 +1256,7 @@ msgstr "page"
 
 #, fuzzy
 msgid "page_not_found"
-msgstr "We could not find that page!"
+msgstr "Sajnos nem találjuk az oldalt!"
 
 #, fuzzy
 msgid "parsons_title"
@@ -1279,10 +1279,10 @@ msgstr "Password of your student is successfully changed."
 
 #, fuzzy
 msgid "password_invalid"
-msgstr "Your password is invalid."
+msgstr "Érvénytelen jelszó."
 
 msgid "password_repeat"
-msgstr "Jelszó mégegyszer"
+msgstr "Jelszó még egyszer"
 
 msgid "password_resetted"
 msgstr "Jelszavadat sikeresen visszaállítottad. Kérjük jelentkezz be."
@@ -1299,7 +1299,7 @@ msgstr "All passwords need to be six characters or longer."
 
 #, fuzzy
 msgid "pending_invites"
-msgstr "Pending invites"
+msgstr "Függőben lévő meghívók"
 
 #, fuzzy
 msgid "people_with_a_link"
@@ -1311,7 +1311,7 @@ msgstr "percentage"
 
 #, fuzzy
 msgid "percentage_achieved"
-msgstr "Achieved by {percentage}% of the users"
+msgstr "A felhasználók {percentage}%-a érte el"
 
 msgid "period"
 msgstr "pont"
@@ -1361,18 +1361,18 @@ msgstr "Profil frissítve."
 
 #, fuzzy
 msgid "profile_picture"
-msgstr "Profile picture"
+msgstr "Profilkép"
 
 msgid "profile_updated"
 msgstr "Profil frissítve."
 
 #, fuzzy
 msgid "profile_updated_reload"
-msgstr "Profile updated, page will be re-loaded."
+msgstr "Profil frissítve, az oldal újratöltődik."
 
 #, fuzzy
 msgid "program_contains_error"
-msgstr "This program contains an error, are you sure you want to share it?"
+msgstr "A programodban hiba van, biztos meg szeretnéd osztani?"
 
 msgid "program_header"
 msgstr "Programjaim"
@@ -1425,7 +1425,7 @@ msgstr "Public profile updated."
 
 #, fuzzy
 msgid "pygame_waiting_for_input"
-msgstr "Waiting for a button press..."
+msgstr "Gombnyomásra várok..."
 
 #, fuzzy
 msgid "question"
@@ -1436,7 +1436,7 @@ msgstr "kérdőjel"
 
 #, fuzzy
 msgid "question_doesnt_exist"
-msgstr "This question does not exist"
+msgstr "Nincs ilyen kérdés"
 
 #, fuzzy
 msgid "question_invalid"
@@ -1493,7 +1493,7 @@ msgid "repeat_match_password"
 msgstr "Az ismételt jelszó nem egyezik."
 
 msgid "repeat_new_password"
-msgstr "Új jelszó mégegyszer"
+msgstr "Új jelszó még egyszer"
 
 #, fuzzy
 msgid "report_failure"
@@ -1662,7 +1662,7 @@ msgstr "Kvíz indítása"
 
 #, fuzzy
 msgid "start_teacher_tutorial"
-msgstr "Start teacher tutorial"
+msgstr "Tanári bemutató indítása"
 
 msgid "step_title"
 msgstr "Feladat"
@@ -1696,7 +1696,7 @@ msgstr "tanulók"
 
 #, fuzzy
 msgid "submission_time"
-msgstr "Handed in at"
+msgstr "Beküldve ekkor:"
 
 #, fuzzy
 msgid "submit_answer"
@@ -1704,19 +1704,19 @@ msgstr "Answer question"
 
 #, fuzzy
 msgid "submit_program"
-msgstr "Submit"
+msgstr "Beküldés"
 
 #, fuzzy
 msgid "submit_warning"
-msgstr "Are you sure you want to submit this program?"
+msgstr "Biztosan beküldöd ezt a programot?"
 
 #, fuzzy
 msgid "submitted"
-msgstr "Submitted"
+msgstr "Beküldve"
 
 #, fuzzy
 msgid "submitted_header"
-msgstr "This is a submitted program and can't be altered."
+msgstr "Ezt a programot már beküldted, ezért nem lehet megváltoztatni."
 
 #, fuzzy
 msgid "subscribe"
@@ -1784,7 +1784,7 @@ msgstr "This turns in your assignment to your teacher."
 
 #, fuzzy
 msgid "title"
-msgstr "Title"
+msgstr "Cím"
 
 #, fuzzy
 msgid "title_achievements"
@@ -1848,23 +1848,23 @@ msgstr "Hedy - Privacy terms"
 
 #, fuzzy
 msgid "title_programs"
-msgstr "Hedy - My programs"
+msgstr "Hedy - Programjaim"
 
 #, fuzzy
 msgid "title_recover"
-msgstr "Hedy - Recover account"
+msgstr "Hedy - Felhasználói fiók visszaállítása"
 
 #, fuzzy
 msgid "title_reset"
-msgstr "Hedy - Reset password"
+msgstr "Hedy - Jelszó visszaállítása"
 
 #, fuzzy
 msgid "title_signup"
-msgstr "Hedy - Create an account"
+msgstr "Hedy - Fiók regisztrálása"
 
 #, fuzzy
 msgid "title_start"
-msgstr "Hedy - A gradual programming language"
+msgstr "Hedy - A fokozatos programnyelv"
 
 #, fuzzy
 msgid "title_view-adventure"
@@ -1876,11 +1876,11 @@ msgstr "Your token is invalid."
 
 #, fuzzy
 msgid "too_many_attempts"
-msgstr "Too many attempts"
+msgstr "Túl sokszor próbálkoztál"
 
 #, fuzzy
 msgid "translate_error"
-msgstr "Something went wrong while translating the code. Try running the code to see if it has an error. Code with errors can not be translated."
+msgstr "Valami baj történt a kód fordítása közben. Próbáld meg futtatni, hogy kiderüljön, van-e benne hiba. A hibás kódot nem lehet lefordítani."
 
 #, fuzzy
 msgid "translating_hedy"
@@ -1888,15 +1888,15 @@ msgstr "Translating Hedy"
 
 #, fuzzy
 msgid "try_it"
-msgstr "Try it"
+msgstr "Próbáld ki"
 
 #, fuzzy
 msgid "tutorial"
-msgstr "Tutorial"
+msgstr "Bemutató"
 
 #, fuzzy
 msgid "tutorial_code_snippet"
-msgstr "Hide cheatsheet"
+msgstr "Súgó elrejtése"
 
 #, fuzzy
 msgid "tutorial_message_not_found"
@@ -1912,7 +1912,7 @@ msgstr "You don't have access rights for this page"
 
 #, fuzzy
 msgid "unique_usernames"
-msgstr "All usernames need to be unique."
+msgstr "A felhasználónévnek egyedinek kell lennie."
 
 #, fuzzy
 msgid "unlock_thresholds"
@@ -1920,7 +1920,7 @@ msgstr "Unlock level thresholds"
 
 #, fuzzy
 msgid "unsaved_class_changes"
-msgstr "There are unsaved changes, are you sure you want to leave this page?"
+msgstr "Biztosan elhagyod ezt az oldalt? Mentetlen változtatásaid vannak, amik így elveszhetnek."
 
 msgid "unshare"
 msgstr "Megosztás megszüntetése"
@@ -1948,25 +1948,25 @@ msgstr "Felhasználónév"
 
 #, fuzzy
 msgid "user_inexistent"
-msgstr "This user doesn't exist"
+msgstr "Nincs ilyen felhasználó"
 
 #, fuzzy
 msgid "user_not_private"
-msgstr "This user doesn't exist or doesn't have a public profile"
+msgstr "Nincs ilyen felhasználó, vagy a profilja nem publikus"
 
 msgid "username"
 msgstr "Felhasználónév"
 
 #, fuzzy
 msgid "username_empty"
-msgstr "You didn't enter an username!"
+msgstr "A felhasználónév nem lehet üres!"
 
 #, fuzzy
 msgid "username_invalid"
-msgstr "Your username is invalid."
+msgstr "Érvénytelen felhasználónév."
 
 msgid "username_special"
-msgstr "A felhaszálónévben nem lehet`:` or `@`."
+msgstr "A felhaszálónévben nem lehet`:` vagy `@`."
 
 msgid "username_three"
 msgstr "A felhasználónévnek legalább három karaktert kell tartalmaznia."
@@ -1977,19 +1977,19 @@ msgstr "One or more usernames is already in use."
 
 #, fuzzy
 msgid "value"
-msgstr "Value"
+msgstr "Érték"
 
 #, fuzzy
 msgid "variables"
-msgstr "Variables"
+msgstr "Változók"
 
 #, fuzzy
 msgid "view_program"
-msgstr "View program"
+msgstr "Mutasd a programot"
 
 #, fuzzy
 msgid "visit_own_public_profile"
-msgstr "Public profile"
+msgstr "Nyilvános profil"
 
 #, fuzzy
 msgid "welcome"
@@ -2008,10 +2008,10 @@ msgid "whole_world"
 msgstr "The world"
 
 msgid "write_first_program"
-msgstr "Írd meg az első programot!"
+msgstr "Írd meg az első programodat!"
 
 msgid "year_invalid"
-msgstr "Adj meg egy évet 1900 és {current_year}"
+msgstr "Adj meg egy évet 1900 és {current_year} között"
 
 msgid "yes"
 msgstr "Igen"


### PR DESCRIPTION
**Description**

* Fixes a mistranslation that caught my eye: General (on the achievement page) was translated to "neme", which means gender. Changing that to "Általános".
* Adds several other translations.

**Note**

Why I'm not using Weblate: it was easier here to find the exact mistranslation that I wanted to fix. Then I just translated things that seemed straightforward enough. I'll use Weblate next time, sorry for the inconvenience.
