### PR TITLE
[RU] Implemented clickable popup windows for the common errors section of the dashboard

### DIFF
--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -2,10 +2,6 @@
 
 {% block popup_content %}
 
-<div>
-
-</div>
-
 <div class="absolute w-full h-full mt-36 top-0 left-0 bg-white bg-opacity-80" style="height: 120%">
     <div class="relative justify-center m-36 pt-10 min-h-full ">
       <h2 class="text-center">Pop Up</h2>

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -6,13 +6,13 @@
 
 </div>
 
-<div class="w-full h-full absolute mt-36 top-0 left-0 bg-white bg-opacity-80">
+<div class="absolute w-full h-full mt-36 top-0 left-0 bg-white bg-opacity-80" style="height: 120%">
     <div class="relative justify-center m-36 pt-10 min-h-full ">
       <h2 class="text-center">Pop Up</h2>
       <div class="w-full max-w-8xl p-2 rounded-lg bg-blue-200 shadow-lg opacity-100" id="card1_progress">
         <a class="no-underline float-right" href="/live_stats/class/{{class_info.id}}">❌</a>
           <div class="pt-10 px-2 pb-2">
-              <h2>❗Error</h2>
+              <h2>❗ Error</h2>
               <p>
                   Jantje has problem
               </p>

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -12,7 +12,10 @@
       <div class="w-full max-w-8xl p-2 rounded-lg bg-blue-200 shadow-lg opacity-100" id="card1_progress">
         <a class="no-underline float-right" href="/live_stats/class/{{class_info.id}}">❌</a>
           <div class="pt-10 px-2 pb-2">
-              <p>Test</p>
+              <h2>❗Error</h2>
+              <p>
+                  Jantje has problem
+              </p>
           </div>
         </p>
       </div>

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -2,9 +2,21 @@
 
 {% block popup_content %}
 
-<div class="absolute top-0 left-0 bg-white bg-transparent">
+<div>
 
-<h1>Test</h1>
+</div>
+
+<div class="w-full h-full absolute mt-36 top-0 left-0 bg-white bg-opacity-80">
+    <div class="relative justify-center m-36 pt-10 min-h-full ">
+      <h2 class="text-center">Pop Up</h2>
+      <div class="w-full max-w-8xl p-2 rounded-lg bg-blue-200 shadow-lg opacity-100" id="card1_progress">
+        <a class="no-underline float-right" href="/live_stats/class/{{class_info.id}}">❌</a>
+          <div class="pt-10 px-2 pb-2">
+              <p>Test</p>
+          </div>
+        </p>
+      </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -4,7 +4,6 @@
 
 <div class="absolute w-full h-full mt-36 top-0 left-0 bg-white bg-opacity-80">
     <div class="relative justify-center m-36 pt-10 min-h-full ">
-      <h2 class="text-center">Pop Up</h2>
       <div class="w-full max-w-8xl p-2 rounded-lg bg-blue-200 shadow-lg opacity-100" id="card1_progress">
         <a class="no-underline float-right" href="/live_stats/class/{{class_info.id}}">❌</a>
           <div class="pt-10 px-2 pb-2">

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -1,0 +1,11 @@
+{% extends "class-live-stats.html" %}
+
+{% block popup_content %}
+
+<div class="absolute top-0 left-0 bg-white bg-transparent">
+
+<h1>Test</h1>
+</div>
+
+{% endblock %}
+

--- a/templates/class-live-popup.html
+++ b/templates/class-live-popup.html
@@ -2,7 +2,7 @@
 
 {% block popup_content %}
 
-<div class="absolute w-full h-full mt-36 top-0 left-0 bg-white bg-opacity-80" style="height: 120%">
+<div class="absolute w-full h-full mt-36 top-0 left-0 bg-white bg-opacity-80">
     <div class="relative justify-center m-36 pt-10 min-h-full ">
       <h2 class="text-center">Pop Up</h2>
       <div class="w-full max-w-8xl p-2 rounded-lg bg-blue-200 shadow-lg opacity-100" id="card1_progress">

--- a/templates/class-live-stats.html
+++ b/templates/class-live-stats.html
@@ -145,9 +145,9 @@
                 {% if class_info.show_c3 %}
                   <div class="w-full text-left p-6">
                       <ul class="max-w-md space-y-1 list-none list-inside">
-                          {{ insert_struggle_list_item('They have an issue with X', 'Student1 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
-                          {{ insert_struggle_list_item('They have an issue with Y', 'Student3 needs help at Lv. 1', '#') }}
-                          {{ insert_struggle_list_item('They have an issue with Z', '2 Students need help', '#') }}
+                          {{ insert_struggle_list_item('Common error X detected', 'Student1 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3~"&student="~s.username) }}
+                          {{ insert_struggle_list_item('Common error Y detected', 'Student3 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
+                          {{ insert_struggle_list_item('Common error Z detected', '2 Students need help', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
                       </ul>
                   </div>
                 {% endif %}

--- a/templates/class-live-stats.html
+++ b/templates/class-live-stats.html
@@ -145,9 +145,9 @@
                 {% if class_info.show_c3 %}
                   <div class="w-full text-left p-6">
                       <ul class="max-w-md space-y-1 list-none list-inside">
-                          {{ insert_struggle_list_item('They have an issue with X', 'Student1 needs help at Lv. 1') }}
-                          {{ insert_struggle_list_item('They have an issue with Y', 'Student3 needs help at Lv. 1') }}
-                          {{ insert_struggle_list_item('They have an issue with Z', '2 Students need help') }}
+                          {{ insert_struggle_list_item('They have an issue with X', 'Student1 needs help at Lv. 1', '/live_stats/class/{{class_info.id}}}/pop_up?show_c1={{class_info.show_c1}}&show_c2={{class_info.show_c2}}&show_c3={{class_info.show_c3}}') }}
+                          {{ insert_struggle_list_item('They have an issue with Y', 'Student3 needs help at Lv. 1', '#') }}
+                          {{ insert_struggle_list_item('They have an issue with Z', '2 Students need help', '#') }}
                       </ul>
                   </div>
                 {% endif %}
@@ -157,4 +157,7 @@
     </div>
 </div>
 
+{% endblock %}
+
+{% block popup_content %}
 {% endblock %}

--- a/templates/class-live-stats.html
+++ b/templates/class-live-stats.html
@@ -155,10 +155,12 @@
             </div>
         </div>
     </div>
+
+    {% block popup_content %}
+    {% endblock %}
 </div>
 
-{% block popup_content %}
-{% endblock %}
+
 
 {% endblock %}
 

--- a/templates/class-live-stats.html
+++ b/templates/class-live-stats.html
@@ -145,7 +145,7 @@
                 {% if class_info.show_c3 %}
                   <div class="w-full text-left p-6">
                       <ul class="max-w-md space-y-1 list-none list-inside">
-                          {{ insert_struggle_list_item('They have an issue with X', 'Student1 needs help at Lv. 1', '/live_stats/class/{{class_info.id}}}/pop_up?show_c1={{class_info.show_c1}}&show_c2={{class_info.show_c2}}&show_c3={{class_info.show_c3}}') }}
+                          {{ insert_struggle_list_item('They have an issue with X', 'Student1 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
                           {{ insert_struggle_list_item('They have an issue with Y', 'Student3 needs help at Lv. 1', '#') }}
                           {{ insert_struggle_list_item('They have an issue with Z', '2 Students need help', '#') }}
                       </ul>
@@ -157,7 +157,9 @@
     </div>
 </div>
 
-{% endblock %}
-
 {% block popup_content %}
 {% endblock %}
+
+{% endblock %}
+
+

--- a/templates/class-live-stats.html
+++ b/templates/class-live-stats.html
@@ -145,7 +145,7 @@
                 {% if class_info.show_c3 %}
                   <div class="w-full text-left p-6">
                       <ul class="max-w-md space-y-1 list-none list-inside">
-                          {{ insert_struggle_list_item('Common error X detected', 'Student1 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3~"&student="~s.username) }}
+                          {{ insert_struggle_list_item('Common error X detected', 'Student1 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
                           {{ insert_struggle_list_item('Common error Y detected', 'Student3 needs help at Lv. 1', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
                           {{ insert_struggle_list_item('Common error Z detected', '2 Students need help', "/live_stats/class/"~class_info.id~"/pop_up?show_c1="~class_info.show_c1~"&show_c2="~class_info.show_c2~"&show_c3="~class_info.show_c3) }}
                       </ul>

--- a/templates/macros/stats-shared.html
+++ b/templates/macros/stats-shared.html
@@ -120,12 +120,14 @@
 </div>
 {% endmacro %}
 
-{% macro insert_struggle_list_item(header, subtext) %}
+{% macro insert_struggle_list_item(header, subtext, link) %}
 
     <li class="relative w-full border-solid border-2 border-black rounded p-2">
-      <h3 class="cursor-pointer hover:text-white">
-        {{header}}
-      </h3>
+      <a class="no-underline"  href="{{ link }}">
+        <h3 class="cursor-pointer hover:text-white">
+          {{header}}
+        </h3>
+      </a>
       <p>
         {{subtext}}
       </p>

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -189,7 +189,10 @@ class StatisticsModule(WebsiteModule):
                 }
             )
 
-        result = self.db.filtered_programs_for_user(student, limit=10)
+        if student:
+            result = self.db.filtered_programs_for_user(student, limit=10)
+        else:
+            result = []
 
         return render_template(
             "class-live-popup.html",

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -172,6 +172,9 @@ class StatisticsModule(WebsiteModule):
         class_ = self.db.get_class(class_id)
         students = sorted(class_.get("students", []))
 
+        # retrieve username of student in question via args
+        student = request.args.get("student", default=None, type=str)
+
         for student_username in class_.get("students", []):
             programs = self.db.programs_for_user(student_username)
             quiz_scores = self.db.get_quiz_stats([student_username])
@@ -186,10 +189,12 @@ class StatisticsModule(WebsiteModule):
                 }
             )
 
+        result = self.db.filtered_programs_for_user(student, limit=10)
+
         return render_template(
             "class-live-popup.html",
             class_info={"id": class_id, "students": students, "collapse": collapse,
-                        "show_c1": show_c1, "show_c2": show_c2, "show_c3": show_c3},
+                        "show_c1": show_c1, "show_c2": show_c2, "show_c3": show_c3, "program_results": result},
             current_page='my-profile',
             page_title=gettext("title_class live_statistics_popup")
         )

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -102,7 +102,7 @@ class StatisticsModule(WebsiteModule):
 
     @route("/live_stats/class/<class_id>/student", methods=["GET"])
     @requires_login
-    def show_student(self, user, class_id):
+    def render_student_details(self, user, class_id):
         """ Shows information about an individual student when they
         are selected in the student list.
         """
@@ -148,6 +148,46 @@ class StatisticsModule(WebsiteModule):
             current_page='my-profile',
             page_title=gettext("title_class live_statistics"),
             javascript_page_options=dict(page='class-live-stats')
+        )
+
+    @route("/live_stats/class/<class_id>/pop_up", methods=["GET"])
+    @requires_login
+    def render_pop_up(self, user, class_id):
+        """
+        Handles the rendering of the pop up items in misconception detection list.
+        """
+        show_c1 = request.args.get("show_c1", default="True", type=str)
+        show_c1 = _determine_bool(show_c1)
+
+        show_c2 = request.args.get("show_c2", default="True", type=str)
+        show_c2 = _determine_bool(show_c2)
+
+        show_c3 = request.args.get("show_c3", default="True", type=str)
+        show_c3 = _determine_bool(show_c3)
+
+        class_ = self.db.get_class(class_id)
+        students = sorted(class_.get("students", []))
+
+        for student_username in class_.get("students", []):
+            programs = self.db.programs_for_user(student_username)
+            quiz_scores = self.db.get_quiz_stats([student_username])
+            # Verify if the user did finish any quiz before getting the max() of the finished levels
+            finished_quizzes = any("finished" in x for x in quiz_scores)
+            highest_quiz = max([x.get("level") for x in quiz_scores if x.get("finished")]) if finished_quizzes else "-"
+            students.append(
+                {
+                    "username": student_username,
+                    "programs": len(programs),
+                    "highest_level": highest_quiz,
+                }
+            )
+
+        return render_template(
+            "class-live-popup.html",
+            class_info={"id": class_id, "students": students,
+                        "show_c1": show_c1, "show_c2": show_c2, "show_c3": show_c3},
+            current_page='my-profile',
+            page_title=gettext("title_class live_statistics_popup")
         )
 
     @route("/logs/class/<class_id>", methods=["GET"])

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -156,6 +156,10 @@ class StatisticsModule(WebsiteModule):
         """
         Handles the rendering of the pop up items in misconception detection list.
         """
+
+        collapse = request.args.get("collapse", default="True", type=str)
+        collapse = _determine_bool(collapse)
+
         show_c1 = request.args.get("show_c1", default="True", type=str)
         show_c1 = _determine_bool(show_c1)
 
@@ -184,7 +188,7 @@ class StatisticsModule(WebsiteModule):
 
         return render_template(
             "class-live-popup.html",
-            class_info={"id": class_id, "students": students,
+            class_info={"id": class_id, "students": students, "collapse": collapse,
                         "show_c1": show_c1, "show_c2": show_c2, "show_c3": show_c3},
             current_page='my-profile',
             page_title=gettext("title_class live_statistics_popup")


### PR DESCRIPTION
The card with common errors/misconceptions now has clickable elements (apart from the reolve which will be a separate issue). 

Relevant technical choices:
- The popup has its own html file which extends the live-page
- it creates a transparent overlay with a slight top margin so the navbar is still clickable but the other elements are not
- macro was changed to include the parameter used in the href link

Test instructions:
- Run hedy locally, login as teacher or admin, navigate to for_teachers/class1/live-dashboard
- Click on any of the three items in the 'Students who are struggling' card
- A page should open looking like this:

<img width="901" alt="Capture" src="https://user-images.githubusercontent.com/50357136/231116343-dedcf566-4a28-47df-a2a7-f15e29b56a44.PNG">


