### PR TITLE
[FIX] Do not autosave if the new program is very small

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -939,7 +939,7 @@ export function runPythonProgram(this: any, code: string, hasTurtle: boolean, ha
       pygameModal.removeClass('bottom-0');
       pygameModal.removeClass('w-full');
     }
-    
+
     document.onkeydown = animateKeys;
     pygameRunning = true;
   }
@@ -1961,7 +1961,14 @@ function programNeedsSaving(adventureName: string) {
   const localStorageCanBeSavedToServer = theUserIsLoggedIn && adventure.save_info === 'local-storage';
   const isUnchangeable = isServerSaveInfo(adventure.save_info) ? adventure.save_info.submitted : false;
 
-  return (programChanged || nameChanged || localStorageCanBeSavedToServer) && !isUnchangeable;
+  // Do not autosave the program if the size is very small compared to the previous
+  // save. This protects against accidental `Ctrl-A, hit a key` and everything is gone. Clicking the
+  // "Run" button will always save regardless of size.
+  const wasSavedBefore = adventure.save_info !== undefined;
+  const suspiciouslySmallFraction = 0.1;
+  const programSuspiciouslyShrunk = wasSavedBefore && theGlobalEditor.getValue().length < adventure.start_code.length * suspiciouslySmallFraction;
+
+  return (programChanged || nameChanged || localStorageCanBeSavedToServer) && !isUnchangeable && !programSuspiciouslyShrunk;
 }
 
 /**


### PR DESCRIPTION
Do not autosave the program if the size is very small compared to the previous save. This protects against accidental `Ctrl-A, hit a key` and everything is gone. Clicking the "Run" button will always save regardless of size.

**How to test**

* Open up the web inspector
* Type some code. Hit "Run", or wait half a minute for it to be saved. (the console will print a message)
* Press `Ctrl-A, Delete`. 
* Wait for 5 minutes.
* Observe that the console will not print a message, the code is not autosaved.