### PR TITLE
[FIX] Log session and user info for all HTTP requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,6 +276,10 @@ def initialize_session():
     utils.session_id()
     login_user_from_token_cookie()
 
+    g.user = current_user()
+    querylog.log_value(session_id=utils.session_id(), username=g.user['username'],
+                       is_teacher=is_teacher(g.user), is_admin=is_admin(g.user))
+
 
 if os.getenv('IS_PRODUCTION'):
     @app.before_request

--- a/website/programs.py
+++ b/website/programs.py
@@ -14,6 +14,7 @@ from .database import Database
 from .website_module import WebsiteModule, route
 from .flask_helpers import proper_jsonify as jsonify
 from .types import SaveInfo, Program
+from . import querylog
 
 
 class ProgramsLogic:
@@ -78,6 +79,9 @@ class ProgramsLogic:
         self.db.increase_user_save_count(user["username"])
         self.achievements.increase_count("saved")
         self.achievements.verify_save_achievements(user["username"], adventure_name)
+
+        querylog.log_value(program_id=program['id'],
+                           adventure_name=adventure_name, error=error, code_lines=len(code.split('\n')))
 
         return program
 


### PR DESCRIPTION
We were not logging user-attributable information for all HTTP requests, only for a couple. This makes it very hard to debug things going wrong.

Make sure we log user-related information with every request (session and username), and emit a couple more bits of information whenever we end up saving a program so it'll be easier to debug weird saving issues.

**How to test**

Nothing to test.