### PR TITLE
[UI FIX] Removes background color from UI when displayed raw

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" href="{{static('/images/Hedy-logo-96x96-laptop.png')}}"/>
     <link rel="stylesheet" href="{{static('/fontawesome/css/all.min.css')}}"/>
   </head>
-  <body id="main_container" dir="{{ g.dir }}" class="bg-gray-100" hx-ext="disable-element">
+  <body id="main_container" dir="{{ g.dir }}" class="{% if not raw %}bg-gray-100{% endif %}" hx-ext="disable-element">
     {% if intro_tutorial or tutorial %}
       <div id="tutorial-mask" class="hidden fixed bg-black z-30 w-full h-full opacity-50"></div>
     {% endif %}


### PR DESCRIPTION
**Description**
Removes the body background color when displayed in raw modus. This is useful when embedding the editor, for example for the slides.

**Fixes**
No related issue.

**How to test**
Verify that no background color is shown when navigating to a raw adventure, for example:
`http://localhost:8080/adventure/story/1/raw`
