### PR TITLE
[FIX] Class customization dropdown closes immediately after opening

### DIFF
--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -1,7 +1,7 @@
 {% extends "auth.html" %}
 {% block regular_content %}
 <div class="flex flex-col gap-2">
-    <h2>{{_('customize_class')}}: {{class_info.name}}</h2>    
+    <h2>{{_('customize_class')}}: {{class_info.name}}</h2>
     <div class="flex flex-col mt-2 border border-gray-400 rounded-lg">
         <h3 class="px-4">{{_('select_adventures')}}</h3>
         <div class="flex flex-row">
@@ -16,14 +16,14 @@
                 <span id="opening_date"></span>
             </div>
             <div id="indicator" class="htmx-indicator custom-indicator ml-4">{{_('updating')}} <i class="fa fa-spinner fa-spin"></i> </div>
-        </div>        
+        </div>
         <div class="flex flex-row w-full mb-4">
             <div class="flex flex-row items-center justify-center mr-2 w-1/12 ml-4">
                 <select class="py-2 px-1 mt-2 h-10 text-center w-full" name="level" id="levels-dropdown"
                         data-cy="adventures"
                         hx-get="/for-teachers/get-customization-level"
-                        hx-target="#adventure-dragger" 
-                        hx-trigger="click"
+                        hx-target="#adventure-dragger"
+                        hx-trigger="input"
                         hx-indicator="#indicator">
                     {% for i in range(1, max_level + 1) %}
                     <option id="select-{{i}}" value="{{ i }}" {% if i == min_level %} selected {% endif %}>
@@ -32,13 +32,13 @@
                     {% endfor %}
                 </select>
             </div>
-            {{ render_partial('customize-class/hx-sortable-adventures.html', 
-                               customizations=customizations, 
-                               max_level=max_level, 
-                               adventure_names=adventure_names, 
+            {{ render_partial('customize-class/hx-sortable-adventures.html',
+                               customizations=customizations,
+                               max_level=max_level,
+                               adventure_names=adventure_names,
                                adventures_default_order=adventures_default_order,
-                               class_id=class_id, 
-                               level=min_level, 
+                               class_id=class_id,
+                               level=min_level,
                                available_adventures=available_adventures)
             }}
         </div>


### PR DESCRIPTION
The level selector dropdown behaves differently in different browsers:

- In Chrome, it opens up and immediately closes.
- In Safari, it doesn't seem to do anything.

This is due to the event we were listening for: `hx-trigger="click"`.

On Chrome, the click event that opens the dropdown immediately triggers the HTMX request. On Safari, `click` doesn't seem to be triggered at all.

Change the event to `hx-trigger="input"`; this gets fired as soon as a value is selected.

**How to test**

Go to the class customization page. Click the level dropdown. It stays open, and clicking an option loads that level.