### PR TITLE
[FIX] Attempt to fix a 500 server error

### DIFF
--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -395,7 +395,7 @@ class ForTeachersModule(WebsiteModule):
 
         for adventure in teacher_adventures:
             if {"name": adventure['id'], "from_teacher": True} not in \
-                    customizations['sorted_adventures'][adventure['level']]:
+                    customizations['sorted_adventures'][str(adventure['level'])]:
                 available_adventures[int(adventure['level'])].append(
                     {"name": adventure['id'], "from_teacher": True})
 


### PR DESCRIPTION
In the server log, I've seen this exception:

```
<ERROR>: Exception on /for-teachers/get-customization-level [GET]

Traceback (most recent call last):

  .....

  File "/app/website/for_teachers.py", line 225, in change_dropdown_level
    customizations, adventure_names, availableadventures,  = self.get_class_info(user, session['class_id'])
  File "/app/website/for_teachers.py", line 347, in get_class_info
    available_adventures = self.get_unused_adventures(customizations, teacher_adventures)
  File "/app/website/for_teachers.py", line 398, in get_unused_adventures
    customizations['sorted_adventures'][adventure['level']]:
KeyError: 1
```

The issue seems to be that `adventure['level']` is the integer `1` and it is not in the `sorted_adventures` dictionary.

I'm not sure how we guarantee that `sorted_adventures` will always have an entry for all levels. It would seem safer to do `customizations['sorted_adventures'].get(adventure['level'], [])` so that we at least fall back to an empty list if the key is not there. I didn't do that, as I don't know the invariants that we expect here.

However, it seems that in the code a couple of lines above, we expect to be indexing `sorted_adventures` with a string, as we are explicitly converting `level` to a string there:
`customizations['sorted_adventures'][str(level)]`

My guess is that we were expecting `adventure['level']` to be a string, but it is in fact an `int`.

The simplest probable fix would be to stringify this value as well, which this PR is doing.

Unfortunately I also don't know how to reproduce this error, so I can't tell you how to test this.
