### PR TITLE
[CHORE] Detect .po file problems during the PR build

### DIFF
--- a/build-tools/github/validate
+++ b/build-tools/github/validate
@@ -16,5 +16,6 @@ else
   $scriptdir/validate-tests
 fi
 $scriptdir/validate-e2e
+python3 $scriptdir/validate-pofiles
 
 echo "Everything is great! 🍰"

--- a/build-tools/github/validate-pofiles
+++ b/build-tools/github/validate-pofiles
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+
 def scan_pofiles(root):
     """Return True if there are any problems."""
     ret = False
@@ -19,6 +20,7 @@ def scan_pofiles(root):
 
 
 PAT = re.compile('^(?:#~ )?msgid "(.*)"')
+
 
 def scan_file(filename):
     with open(filename, 'r', encoding='utf-8') as f:
@@ -47,8 +49,6 @@ def scan_file(filename):
             print('')
 
     return True
-
-
 
 
 if __name__ == '__main__':

--- a/build-tools/github/validate-pofiles
+++ b/build-tools/github/validate-pofiles
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Check all .po files, and make sure they don't have duplicate msgid's in there.
+# (Perhaps normal and commented out).
+from os import path
+import collections
+import os
+import re
+import sys
+
+def scan_pofiles(root):
+    """Return True if there are any problems."""
+    ret = False
+    for dir, _, files in os.walk(root):
+        for file in files:
+            if file.endswith('.po'):
+                fullpath = path.join(dir, file)
+                ret |= scan_file(fullpath)
+    return ret
+
+
+PAT = re.compile('^(?:#~ )?msgid "(.*)"')
+
+def scan_file(filename):
+    with open(filename, 'r', encoding='utf-8') as f:
+        lines = f.read().splitlines()
+
+    indexes = collections.defaultdict(list)
+    for i, line in enumerate(lines):
+        m = PAT.match(line)
+        if m:
+            indexes[m.group(1)].append(i)
+
+    morethanonce = [(word, lines) for word, lines in indexes.items() if len(lines) > 1]
+    if len(morethanonce) == 0:
+        return False
+
+    print('-' * 70)
+    print(filename)
+    print('-' * 70)
+
+    for word, linenrs in morethanonce:
+        print(f"The translation of '{word}' occurs {len(linenrs)} times:")
+        print('')
+        for nr in linenrs:
+            print(f'    {nr + 1}: {lines[nr]}')
+            print(f'    {nr + 2}: {lines[nr + 1]}')
+            print('')
+
+    return True
+
+
+
+
+if __name__ == '__main__':
+    fail = scan_pofiles(path.join(path.dirname(__file__), '..', '..', 'translations'))
+    if fail:
+        print('Something went wrong with the gettext translation files, some entries were duplicated.')
+        print('See above for the list. Please make sure every msgid occurs only once,')
+        print('not commented out, with the right translation.')
+        sys.exit(1)


### PR DESCRIPTION
For reasons we're not quite sure of, sometimes translations get lost while generating `.po` files. A situation that happens sometimes is that we end up with the following in a file:

```
msgid "mandatory_mode"
msgstr ""

(...a lot further down...)

\#~ msgid "mandatory_mode"
\#~ msgstr "Mandatory Developer's Mode
```

For some reason the correct translation is commented out and replaced with an empty string one.

This PR adds a script that will detect this situation and fail the build on the PR that tries to accidentally introduce this situation.

**How to test**

The build on this PR will currently fail, as the `main` branch is currently in this broken state.

Once the main branch is fixed and merged into this PR, the build will start passing.