### PR TITLE
[UI] Fix appeareance of adventure dragger when overflowing

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1176,6 +1176,9 @@ msgid "reset_adventure_prompt"
 msgstr ""
 
 msgid "reset_adventures"
+msgstr ""
+
+msgid "reset_button"
 msgstr ""
 
 msgid "reset_password"

--- a/static/css/generated.full.css
+++ b/static/css/generated.full.css
@@ -5461,6 +5461,10 @@ code {
   margin-left: 0.5rem;
 }
 
+.ml-6 {
+  margin-left: 1.5rem;
+}
+
 .ml-0 {
   margin-left: 0px;
 }
@@ -6257,10 +6261,6 @@ code {
   margin-left: 1.25rem;
 }
 
-.ml-6 {
-  margin-left: 1.5rem;
-}
-
 .ml-7 {
   margin-left: 1.75rem;
 }
@@ -6852,6 +6852,10 @@ code {
   max-height: 100%;
 }
 
+.max-h-56 {
+  max-height: 14rem;
+}
+
 .max-h-0 {
   max-height: 0px;
 }
@@ -6946,10 +6950,6 @@ code {
 
 .max-h-52 {
   max-height: 13rem;
-}
-
-.max-h-56 {
-  max-height: 14rem;
 }
 
 .max-h-60 {
@@ -7070,18 +7070,6 @@ code {
   width: 16rem;
 }
 
-.w-3\/12 {
-  width: 25%;
-}
-
-.w-9\/12 {
-  width: 75%;
-}
-
-.w-12 {
-  width: 3rem;
-}
-
 .w-fit {
   width: -moz-fit-content;
   width: fit-content;
@@ -7105,6 +7093,10 @@ code {
 
 .w-4\/5 {
   width: 80%;
+}
+
+.w-12 {
+  width: 3rem;
 }
 
 .w-14 {
@@ -7285,6 +7277,10 @@ code {
   width: 83.333333%;
 }
 
+.w-3\/12 {
+  width: 25%;
+}
+
 .w-4\/12 {
   width: 33.333333%;
 }
@@ -7305,8 +7301,20 @@ code {
   width: 66.666667%;
 }
 
+.w-9\/12 {
+  width: 75%;
+}
+
 .w-11\/12 {
   width: 91.666667%;
+}
+
+.min-w-\[100px\] {
+  min-width: 100px;
+}
+
+.min-w-\[200px\] {
+  min-width: 200px;
 }
 
 .min-w-min {
@@ -19959,16 +19967,6 @@ code {
   background-color: rgb(198 246 213 / var(--tw-bg-opacity));
 }
 
-.bg-green-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(104 211 145 / var(--tw-bg-opacity));
-}
-
-.bg-red-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(252 129 129 / var(--tw-bg-opacity));
-}
-
 .bg-current {
   background-color: currentColor;
 }
@@ -20001,6 +19999,11 @@ code {
 .bg-red-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 178 178 / var(--tw-bg-opacity));
+}
+
+.bg-red-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 129 129 / var(--tw-bg-opacity));
 }
 
 .bg-red-600 {
@@ -20081,6 +20084,11 @@ code {
 .bg-yellow-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(116 66 16 / var(--tw-bg-opacity));
+}
+
+.bg-green-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(104 211 145 / var(--tw-bg-opacity));
 }
 
 .bg-green-700 {
@@ -22993,11 +23001,6 @@ code {
   padding-bottom: 0.75rem;
 }
 
-.py-1 {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
-
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
@@ -23006,6 +23009,11 @@ code {
 .py-12 {
   padding-top: 3rem;
   padding-bottom: 3rem;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
 }
 
 .px-16 {

--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -17,8 +17,8 @@
             </div>
             <div id="indicator" class="htmx-indicator custom-indicator ml-4">{{_('updating_indicator')}} <i class="fa fa-spinner fa-spin"></i> </div>
         </div>
-        <div class="flex flex-row w-full mb-4">
-            <div class="flex flex-row items-center justify-center mr-2 w-1/12 ml-4">
+        <div class="flex flex-row w-full mb-4 overflow-x-auto">
+            <div class="items-center justify-center mr-2 w-1/12 ml-4 min-w-[100px]">
                 <select class="py-2 px-1 mt-2 h-10 text-center w-full" name="level" id="levels-dropdown"
                         data-cy="adventures"
                         hx-get="/for-teachers/get-customization-level"

--- a/templates/customize-class/hx-sortable-adventures.html
+++ b/templates/customize-class/hx-sortable-adventures.html
@@ -1,6 +1,7 @@
 <div class="flex flex-row w-full" id="adventure-dragger">
     <div id="sortadventures" data-cy="sortadventures" class="flex flex-row w-10/12">   
         <div id="level-{{ level }}" data-cy="level-{{ level }}" class="adventures-tab flex sortable" 
+            style="transform: translate3d(0, 0, 0)"
             hx-trigger="end"
             hx-post="/for-teachers/sort-adventures?level={{ level }}"
             hx-target="#adventure-dragger" 
@@ -21,7 +22,7 @@
                 {% endfor %}
         </div>
     </div>
-    <select class="py-2 px-1 w-full mt-2 h-10 text-center ml-2 w-2/12" name="adventure_id" id="available"
+    <select class="py-2 px-1 w-full mt-2 h-10 text-center ml-2 w-2/12 min-w-[200px]" name="adventure_id" id="available"
             data-cy="available_adventures_current_level"
             hx-post="/for-teachers/add-adventure/level/{{ level }}"                
             hx-target="#adventure-dragger"
@@ -34,7 +35,7 @@
             </option>
         {% endfor %}
     </select> 
-    <button class="yellow-btn text-white mr-4 ml-6 place-self-center" hx-get="/for-teachers/restore-adventures-modal/level/{{ level }}" hx-target="#modal-target">
-        {{_('reset_adventures')}}
+    <button title="{{_('reset_adventures')}}" class="yellow-btn text-white mr-4 ml-6 place-self-center" hx-get="/for-teachers/restore-adventures-modal/level/{{ level }}" hx-target="#modal-target">
+        {{_('reset_button')}}
     </button>
 </div>

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ar\n"
@@ -1296,6 +1296,9 @@ msgstr "هل أنت متأكد أنك تريد إعادة ضبط كل المغا
 
 msgid "reset_adventures"
 msgstr "إعادة ضبط المغامرات المختارة"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "اعادة ضبط كلمة المرور"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bg\n"
@@ -1496,6 +1496,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bn\n"
@@ -1566,6 +1566,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ca\n"
@@ -1527,6 +1527,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cs\n"
@@ -1487,6 +1487,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Obnovit heslo"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cy\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: da\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
@@ -1204,6 +1204,9 @@ msgstr "Bist du dir sicher, dass du alle ausgewählten Abenteuer zurücksetzen m
 
 msgid "reset_adventures"
 msgstr "Ausgewählte Abenteuer zurücksetzen"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Passwort zurücksetzen"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: el\n"
@@ -1329,6 +1329,9 @@ msgstr "Είσαι βέβαιος ότι θέλεις να επαναφέρει�
 
 msgid "reset_adventures"
 msgstr "Επανάφερε επιλεγμένες περιπέτειες"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Επαναφορά συνθηματικού"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-03-21 09:01+0000\n"
 "Last-Translator: Jesús Pelay <pelayjesus@gmail.com>\n"
 "Language: en\n"
@@ -1206,6 +1206,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr "Reset"
 
 msgid "reset_password"
 msgstr "Reset password"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -727,7 +727,7 @@ msgid "level_disabled"
 msgstr "Level disabled"
 
 msgid "level_future"
-msgstr "This level will open automatically after the opening date"
+msgstr "This level automatically opens on "
 
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: eo\n"
@@ -1374,6 +1374,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: es\n"
@@ -1204,6 +1204,9 @@ msgstr "¿Seguro que quieres restablecer todas las aventuras seleccionadas?"
 
 msgid "reset_adventures"
 msgstr "Restablecer aventuras seleccionadas"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Establecer nueva contraseña"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: et\n"
@@ -1541,6 +1541,9 @@ msgstr "Oled sa kindel, et sa tahad valitud seiklused lähtestada?"
 
 msgid "reset_adventures"
 msgstr "Lähtesta valitud seiklused"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Lähtesta salasõna"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fa\n"
@@ -1557,6 +1557,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fi\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fr\n"
@@ -1291,6 +1291,9 @@ msgstr "Est tu sur de vouloir remettre à zéro toutes les aventures sélectionn
 
 msgid "reset_adventures"
 msgstr "Réinitialiser les aventures sélectionnées"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Réinitialiser le mot de passe"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fy\n"
@@ -1473,6 +1473,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Dyn wachtwurd resette"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: he\n"
@@ -1527,6 +1527,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hi\n"
@@ -1358,6 +1358,9 @@ msgstr "क्या आप वाकई सभी चयनित adventures �
 
 msgid "reset_adventures"
 msgstr "चयनित adventures रीसेट करें"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "सांकेतिक शब्द को फिर से कायम करें"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hu\n"
@@ -1474,6 +1474,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Jelszó törlése"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: id\n"
@@ -1463,6 +1463,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Set ulang password"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: it\n"
@@ -1506,6 +1506,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Resetta password"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ja\n"
@@ -1568,6 +1568,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: kmr\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ko\n"
@@ -1580,6 +1580,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: nb_NO\n"
@@ -1315,6 +1315,9 @@ msgstr "Er du sikker på at du vil tilbakestille alle valgte eventyr?"
 
 msgid "reset_adventures"
 msgstr "Tilbakestill valgte eventyr"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Tilbakestill passord"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: nl\n"
@@ -1234,6 +1234,9 @@ msgstr "Weet je zeker dat je alle geselecteerde avonturen wilt wissen?"
 
 msgid "reset_adventures"
 msgstr "Wis gekozen avonturen"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Reset je wachtwoord"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pa_PK\n"
@@ -1583,6 +1583,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-17 17:38+0000\n"
 "Last-Translator: Marcin Serwin <marcin.serwin0@protonmail.com>\n"
 "Language: pl\n"
@@ -1202,6 +1202,9 @@ msgstr "Czy jesteś pewien, że chcesz zresetować wybrane przygody?"
 
 msgid "reset_adventures"
 msgstr "Resetuj wybrane przygody"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Zresetuj hasło"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_BR\n"
@@ -1473,6 +1473,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Redefinir senha"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_PT\n"
@@ -1495,6 +1495,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Reiniciar palavra-passe"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-22 16:49+0000\n"
 "Last-Translator: SabinaChita <s.m.chita@vu.nl>\n"
 "Language: ro\n"
@@ -1582,6 +1582,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ru\n"
@@ -1204,6 +1204,9 @@ msgstr "Вы уверены, что хотите сбросить все выб�
 
 msgid "reset_adventures"
 msgstr "Сброс выбранных приключений"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Сброс пароля"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sq\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sr\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sv\n"
@@ -1566,6 +1566,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sw\n"
@@ -1504,6 +1504,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "Badilisha nenosiri"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: te\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: th\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: tl\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: tn\n"
@@ -1579,6 +1579,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: tr\n"
@@ -1559,6 +1559,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-17 13:58+0000\n"
 "Last-Translator: \"Denys M.\" <dector@dector.space>\n"
 "Language: uk\n"
@@ -1384,6 +1384,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ur\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: vi\n"
@@ -1582,6 +1582,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: zh_Hans\n"
@@ -1324,6 +1324,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 msgid "reset_password"
 msgstr "重置密码"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-15 11:37-0400\n"
+"POT-Creation-Date: 2023-05-16 11:32-0400\n"
 "PO-Revision-Date: 2023-04-06 07:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: zh_Hant\n"
@@ -1585,6 +1585,9 @@ msgstr "Are you sure you want to reset all selected adventures?"
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
+
+msgid "reset_button"
+msgstr ""
 
 #, fuzzy
 msgid "reset_password"


### PR DESCRIPTION
There was an issue when editting level five in the customizations:

![image](https://github.com/hedyorg/hedy/assets/45865185/f0758563-7cad-4ce8-9fc1-6b203c2611c9)

It looks terrible because the text in the button is taking too much space, so now this PR adds a tooltip and a new label to the button, which is now 'Reset' looking like this now:

![image](https://github.com/hedyorg/hedy/assets/45865185/3d27f2fa-261a-4583-8ba4-445b61b49522)

Another thing that this PR fixes is the overflowing behavior, when you resized the screen, the `selects` also resized and become tiny. Now they have a minimum width and the whole div becomes scrollable:

![image](https://github.com/hedyorg/hedy/assets/45865185/d66b7447-ef21-41ff-a333-ee162ec9a6b2)

In Firefox, this causes a bit of a problem because Firefox has a different (and in my opinion worst) approach to scroll bars, being able to just use the outer scroll bar:

https://github.com/hedyorg/hedy/assets/45865185/b0696e14-a5db-49bf-8fcf-fffd9cc6df6f


Lastly, also changes the value of the `level_future` key in Babel so it reads more nicely:

![image](https://github.com/hedyorg/hedy/assets/45865185/05e38277-ae82-4cf9-bf61-313fd214a39c)
