### PR TITLE
[FIX] The output window grows with all output

### DIFF
--- a/templates/incl/editor-and-output.html
+++ b/templates/incl/editor-and-output.html
@@ -114,7 +114,7 @@
         </div>
       </div>
     </div>
-    <div class="w-full flex flex-col order-3 relative" id="code_output">
+    <div class="w-full flex flex-col order-3 relative" id="code_output" style="max-height: 22rem;">
         <div class="inline-block ltr:right-0 rtl:left-0 absolute z-10 mx-2 mt-2 text-white" id="variables_container">
             <button id="variable_button" class="inline-flex items-center text-xl px-2 bg-blue-600 rounded-lg" onclick="hedyApp.showVariableView()">
                 🏷<svg class="float-right w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
In https://github.com/hedyorg/hedy/pull/4215, the `height: 22rem` style attribute was removed from the program output, which stops it from restricting its height and makes it grow with the output.

Revert that.
