### PR TITLE
[CHORE] Remove headers from .po files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,9 @@ When adding new Babel translations the implementation is a bit more complex, but
     * Notice that the `{{ }}` characters are Jinja2 template placeholders for variables
     * When on the back-end we do this like this: `gettext('test')`
 2. Next we run the following command to let Babel search for keys, it is important to locations and sort the output to minimize merge conflicts:
-    * `pybabel extract -F babel.cfg -o messages.pot . --no-location --sort-output`
+    * `pybabel extract -F babel.cfg -o messages.pot . --no-location --sort-output --omit-header`
 3. We now have to add the found keys to all translation files, with the following command:
-    * `pybabel update -i messages.pot -d translations -N  --no-wrap`
+    * `pybabel update -i messages.pot -d translations -N  --no-wrap --omit-header`
 4. All keys will be automatically stored in the /translations folder
 5. Search for the .po files for the languages you know and find the empty `msgstr` for your added key(s)
 6. Add your translations there, the other translation will hopefully be quickly picked up by other translators

--- a/build-tools/github/validate-pofiles
+++ b/build-tools/github/validate-pofiles
@@ -15,14 +15,15 @@ def scan_pofiles(root):
         for file in files:
             if file.endswith('.po'):
                 fullpath = path.join(dir, file)
-                ret |= scan_file(fullpath)
+                ret |= scan_file_for_duplicates(fullpath)
+                ret |= scan_file_for_header(fullpath)
     return ret
 
 
 PAT = re.compile('^(?:#~ )?msgid "(.*)"')
 
 
-def scan_file(filename):
+def scan_file_for_duplicates(filename):
     with open(filename, 'r', encoding='utf-8') as f:
         lines = f.read().splitlines()
 
@@ -48,13 +49,29 @@ def scan_file(filename):
             print(f'    {nr + 2}: {lines[nr + 1]}')
             print('')
 
+    print('Something went wrong with the gettext translation file, some entries were duplicated.')
+    print('See above for the list. Please make sure every msgid occurs only once,')
+    print('not commented out, with the right translation.')
+
+    return True
+
+
+def scan_file_for_header(filename):
+    with open(filename, 'r', encoding='utf-8') as f:
+        contents = f.read()
+
+    if 'Project-Id-Version:' not in contents:
+        return False
+    print('-' * 70)
+    print(filename)
+    print('-' * 70)
+
+    print('Found "Project-Id-Version:" in the file. Be sure to run the pybabel commands with \'--omit-header\'!')
+
     return True
 
 
 if __name__ == '__main__':
     fail = scan_pofiles(path.join(path.dirname(__file__), '..', '..', 'translations'))
     if fail:
-        print('Something went wrong with the gettext translation files, some entries were duplicated.')
-        print('See above for the list. Please make sure every msgid occurs only once,')
-        print('not commented out, with the right translation.')
         sys.exit(1)

--- a/messages.pot
+++ b/messages.pot
@@ -1,22 +1,3 @@
-# Translations template for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 msgid "Access Before Assign"
 msgstr ""
 

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ar\n"
-"Language-Team: ar <LL@li.org>\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: bg\n"
-"Language-Team: bg <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: bn\n"
-"Language-Team: bn <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Catalan translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ca\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: cs\n"
-"Language-Team: cs <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Welsh translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: cy\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : (n==3) ? 3 :(n==6) ? 4 : 5;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Danish translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: da\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: de\n"
-"Language-Team: de <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "Du hast versucht die Variable {name} auf Zeile {access_line_number} zu benutzen, aber du hast sie auf Zeile {definition_line_number} gesetzt. Setze eine Variable bevor du sie benutzt."

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: el\n"
-"Language-Team: el <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# English translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-03-21 09:01+0000\n"
-"Last-Translator: Jesús Pelay <pelayjesus@gmail.com>\n"
-"Language: en\n"
-"Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."
 

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: eo\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: es\n"
-"Language-Team: es <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "Has intentado usar la variable {name} en la línea {access_line_number}, pero ya la has definido en la línea {definition_line_number}. Define una variable antes de usarla."

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Estonian translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: et\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: fa\n"
-"Language-Team: fa <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Finnish translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: fi\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: fr\n"
-"Language-Team: fr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: fy\n"
-"Language-Team: fy <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Hebrew translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: he\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && n % 10 == 0) ? 2 : 3));\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "ניסיתם להשתמש במשתנה {name} בשורה {access_line_number}, אבל הגדרתם אותו רק בשורה {definition_line_number}. צריך להגדיר משתנים לפני שמשתמשים בהם."

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: hi\n"
-"Language-Team: hi <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: hu\n"
-"Language-Team: hu <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "A {name} nevű változót a {access_line_number}. sorban próbáltad használni, de csak a {definition_line_number}. sorban hoztad létre. A változókat előbb létre kell hoznod, csak utána tudod használni őket."

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: id\n"
-"Language-Team: id <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: it\n"
-"Language-Team: it <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Japanese translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ja\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Kurdish (Turkey) translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: kmr\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Korean translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ko\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: nb_NO\n"
-"Language-Team: nb_NO <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Dutch translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: nl\n"
-"Language-Team: nl <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Punjabi (Arabic, Pakistan) translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: pa_PK\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-17 17:38+0000\n"
-"Last-Translator: Marcin Serwin <marcin.serwin0@protonmail.com>\n"
-"Language: pl\n"
-"Language-Team: pl <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 msgid "Access Before Assign"
 msgstr "Próbowano użyć zmiennej {name} w linii {access_line_number}, ale ustawiono ją w linii {definition_line_number}. Ustaw zmienną przed jej użyciem."
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: pt_BR\n"
-"Language-Team: pt_BR <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: pt_PT\n"
-"Language-Team: pt_PT <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Romanian translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-22 16:49+0000\n"
-"Last-Translator: SabinaChita <s.m.chita@vu.nl>\n"
-"Language: ro\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ru\n"
-"Language-Team: ru <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "Вы использовали переменную {name} на строке {access_line_number}, но вы присваиваете ей значение на строке {definition_line_number}. Присвойте значение до того как используете переменную."

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Albanian translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: sq\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Serbian translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: sr\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Swedish translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: sv\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: sw\n"
-"Language-Team: sw <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Telugu translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: te\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Thai translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: th\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Filipino (Philippines) translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: tl\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1 && n != 2 && n != 3 && (n % 10 == 4 || n % 10 == 6 || n % 10 == 9);\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -1,22 +1,3 @@
-# tn translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: tn\n"
-"Language-Team: none\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: tr\n"
-"Language-Team: tr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Ukrainian translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-17 13:58+0000\n"
-"Last-Translator: \"Denys M.\" <dector@dector.space>\n"
-"Language: uk\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Urdu translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: ur\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Vietnamese translations for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: vi\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1,19 +1,3 @@
-
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: zh_Hans\n"
-"Language-Team: zh_Hans <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "你试图在第{access_line_number}行使用变量{name}，但你在第{definition_line_number}行才设置了它。使用变量前要先设置。"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -1,23 +1,3 @@
-# Chinese (Traditional) translations for PROJECT.
-# Copyright (C) 2023 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-05-18 12:09+0200\n"
-"PO-Revision-Date: 2023-04-06 07:18+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language: zh_Hant\n"
-"Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
-
 #, fuzzy
 msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."


### PR DESCRIPTION
The headers in the `.po` files don't really add a lot of value, but the time stamps in them do cause merge conflicts constantly.

Remove the headers, update the commands in `CONTRIBUTING.md` to include the `--omit-header` flag, and add a validation script that will fail if someone runs a babel command from shell history and the headers are re-added.
