### PR TITLE
[CHORE] Remove `--no-wrap` from recommended `pybabel` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ When adding new Babel translations the implementation is a bit more complex, but
 2. Next we run the following command to let Babel search for keys, it is important to locations and sort the output to minimize merge conflicts:
     * `pybabel extract -F babel.cfg -o messages.pot . --no-location --sort-output`
 3. We now have to add the found keys to all translation files, with the following command:
-    * `pybabel update -i messages.pot -d translations -N  --no-wrap`
+    * `pybabel update -i messages.pot -d translations -N`
 4. All keys will be automatically stored in the /translations folder
 5. Search for the .po files for the languages you know and find the empty `msgstr` for your added key(s)
 6. Add your translations there, the other translation will hopefully be quickly picked up by other translators


### PR DESCRIPTION
When Weblate writes `.po` files, it will always use wrapping.

When we then recommend to disable wrapping, we trigger an endless fight between ourselves and Weblate where we will unwrap a line and Weblate will wrap it and then we will unwrap it and so forth...
