### PR TITLE
[UI] Fix unreadable quiz output

### DIFF
--- a/templates/quiz/hx-question.html
+++ b/templates/quiz/hx-question.html
@@ -7,7 +7,7 @@
     {% include "quiz/incl-question-progress.html" %}
     <div>
         <div class="my-10 text-3xl font-bold text-blue-900 text-center">
-            {{ question.text|commonmark }}
+            {{ question.text }}
         </div>
         {% if question.code %}
         <div class="turn-pre-into-ace w-2/3 max-w-3xl mx-auto my-4 ace-container">

--- a/templates/quiz/hx-question.html
+++ b/templates/quiz/hx-question.html
@@ -7,17 +7,17 @@
     {% include "quiz/incl-question-progress.html" %}
     <div>
         <div class="my-10 text-3xl font-bold text-blue-900 text-center">
-            {{ question.text }}
+            {{ question.text|commonmark }}
         </div>
         {% if question.code %}
-        <div class="turn-pre-into-ace w-3/4 max-w-3xl mx-auto my-4 ace-container">
+        <div class="turn-pre-into-ace w-2/3 max-w-3xl mx-auto my-4 ace-container">
             <pre class="quiz-question" level="{{ level }}">{{ question.code }}</pre>
         </div>
         {% endif %}
 
         {% if question.output %}
-        <div class="w-3/4 mx-auto my-4 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto">
-            {{ question.output }}
+        <div class="w-2/3 mx-auto my-4 rounded p-2 px-3 bg-gray-900 color-white text-lg overflow-auto">
+            <pre>{{ question.output }}</pre>
         </div>
         {% endif %}
 


### PR DESCRIPTION
The quiz has an `output` field that gets rendered to show the output of a hypothetical program. The output was being rendered as black text on a dark blue background, and barely readable.

Make it readable and treat the text as `<pre>`formatted.

Also change the width of code and output containers to look slightly nicer.

**How to test**

http://localhost:8080/quiz/preview-question/9/5 will show the difference.

Before:

<img width="1721" alt="image" src="https://github.com/hedyorg/hedy/assets/524162/c68de2f9-72be-42e9-bf7d-25a9c52d2557">

After:

<img width="1236" alt="image" src="https://github.com/hedyorg/hedy/assets/524162/14a95ca9-e531-455c-8301-313013143c95">
