### PR TITLE
[FIX] Reset height fix

### DIFF
--- a/templates/incl/editor-and-output.html
+++ b/templates/incl/editor-and-output.html
@@ -114,7 +114,7 @@
         </div>
       </div>
     </div>
-    <div class="w-full flex flex-col order-3 relative" id="code_output">
+    <div class="w-full flex flex-col order-3 relative" id="code_output" style="height: 22rem;">
         <div class="inline-block ltr:right-0 rtl:left-0 absolute z-10 mx-2 mt-2 text-white" id="variables_container">
             <button id="variable_button" class="inline-flex items-center text-xl px-2 bg-blue-600 rounded-lg" onclick="hedyApp.showVariableView()">
                 🏷<svg class="float-right w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This bug has a fun backstory :) 

#4215 introduced an issue where code now expands the output box, then #4302 fixed that, but caused a new issue (a gap in the programmer's mode) which #4317 fixes, but that again caused the output expansion to resurface. This reverts the original change that was not even needed since we have the if in the raw already.

Lesson learned: I should not touch the front-end without adult supervision :)