### PR TITLE
[FIX] Grid page failing

### DIFF
--- a/website/statistics.py
+++ b/website/statistics.py
@@ -255,9 +255,10 @@ class StatisticsModule(WebsiteModule):
                 ticked_adventures[student] = []
                 current_program = {}
                 for _, program in programs.items():
-                    print('*'*100)
-                    print(f'program {program} for student {student}')
-                    print('*'*100)
+                    # Old programs sometimes don't have adventures associated to them
+                    # So skip them
+                    if 'adventure_name' not in program:
+                        continue
                     name = adventure_names.get(program['adventure_name'], program['adventure_name'])
                     customized_level = class_adventures_formatted.get(str(program['level']))
                     if name in customized_level:


### PR DESCRIPTION
Classes with old programs were failing because some of them did not have the field `adventure_name`. This PR adds an if when retrieving programs that have this characteristic. It also deletes the debug prints that were added in #4416.