### PR TITLE
[FIX] Grid not working when there are no customizations

### DIFF
--- a/website/statistics.py
+++ b/website/statistics.py
@@ -228,6 +228,8 @@ class StatisticsModule(WebsiteModule):
         students = sorted(class_.get("students", []))
         teacher_adventures = self.db.get_teacher_adventures(user["username"])
         class_info = self.db.get_class_customizations(class_id)
+        if not class_info:
+            class_info = self._create_customizations(class_id)
         class_adventures = class_info.get('sorted_adventures')
 
         adventure_names = {}
@@ -276,6 +278,21 @@ class StatisticsModule(WebsiteModule):
                         ticked_adventures[student].append(current_program)
 
         return students, class_, class_adventures_formatted, ticked_adventures, adventure_names, student_adventures
+
+    def _create_customizations(self, class_id):
+        sorted_adventures = {}
+        for lvl, adventures in hedy_content.ADVENTURE_ORDER_PER_LEVEL.items():
+            sorted_adventures[str(lvl)] = [{'name': adventure, 'from_teacher': False} for adventure in adventures]
+        customizations = {
+            "id": class_id,
+            "levels": [i for i in range(1, hedy.HEDY_MAX_LEVEL + 1)],
+            "opening_dates": {},
+            "other_settings": [],
+            "level_thresholds": {},
+            "sorted_adventures": sorted_adventures
+        }
+        self.db.update_class_customizations(customizations)
+        return customizations
 
 
 def add(username, action):

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -239,7 +239,7 @@ class StatisticsModule(WebsiteModule):
             self.db.update_class_customizations(class_info)
         else:
             # Create a new default customizations object in case it doesn't have one
-            class_info = self._create_customizations(self, class_id)
+            class_info = self._create_customizations(class_id)
 
         class_adventures = class_info.get('sorted_adventures')
 


### PR DESCRIPTION
**Description**

The Grid page fails when it tries to load customizations for a class that doesn't have any, of course this causes an error because it's then trying to access a field that isn't there. This PR fixes that mistake by creating a new default customizations object in case there ins't one. 

**How to test**
You can run `./feed_dev_database` and then delete the only customizations object in the database. Access the Grid for that class and it should work
