### PR TITLE
[FIX] catch empty list

### DIFF
--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -378,7 +378,7 @@ class ForTeachersModule(WebsiteModule):
                         customizations['sorted_adventures'][str(level)].append(
                             {"name": adventure, "from_teacher": False})
             self.db.update_class_customizations(customizations)
-            min_level = min(customizations['levels'])
+            min_level = 1 if customizations['levels'] == [] else min(customizations['levels'])
         else:
             # Since it doesn't have customizations loaded, we create a default customization object.
             # This makes further updating with HTMX easier


### PR DESCRIPTION
There was an issue in classes (reported by a teacher) where the customization page would error out unexpectedly. The issue seems to be when there are customizations (the page has been accessed) but nothing has been yet saved so the list of levels is empty. This is a proven fix for the reporting teacher, I hope for all cases!