### PR TITLE
[FIX] Try to fix and log quiz issues better

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,6 +356,7 @@ def setup_language():
         session['lang'] = request.accept_languages.best_match(
             ALL_LANGUAGES.keys(), 'en')
     g.lang = session['lang']
+    querylog.log_value(lang=session['lang'])
 
     if 'keyword_lang' not in session:
         session['keyword_lang'] = g.lang if g.lang in ALL_KEYWORD_LANGUAGES.keys() else 'en'

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -87,7 +87,10 @@ class Achievements:
             session["submitted_programs"] += 1
 
     def add_single_achievement(self, username, achievement):
-        """Record an achievement for this user, return the list of achievements earned so far."""
+        """Record an achievement for this user.
+
+        Returns all new achievements recorded in this way, or the special value 'None' in case
+        the operation could not be performed."""
         self.initialize_user_data_if_necessary()
         if achievement not in session["achieved"] and achievement in self.translations.get_translations(
             session["lang"]


### PR DESCRIPTION
We have gotten the following reports from the quiz module:

- Some student has gotten Python exceptions while doing the quiz, caused by a `list index out of range` error.
- Another student has gotten `400` errors saying `No such question`.

Trying to address the first issue by assuming the error was caused by the achievement handling code at the end of a quiz: that code was a little waffly about the return type of `add_single_achievement`; write code that can deal with either return value.

For the other issue (and also in case we get the first issue wrong), start logging more details about the quiz state and 

**How to test**

Start the server, click around in the Quiz. Observe that fields like `level` and `question` are logged to the console in the giant dictionary:

![2023-09-06 at 14 01](https://github.com/hedyorg/hedy/assets/524162/97576d6c-a204-4036-92b9-1dda50213c7e)

