### PR TITLE
[FIX] Remove failing tests

### DIFF
--- a/tests/cypress/e2e/hedy_page/editor_box.cy.js
+++ b/tests/cypress/e2e/hedy_page/editor_box.cy.js
@@ -21,7 +21,7 @@ describe('Is able to type in the editor box', () => {
   }
 });
 
-/* TODO: We need to fix this tests so they don't fail every time we execute them on GitHub actions
+/* TODO: We need to fix these tests so they don't fail every time we execute them on GitHub actions
 
 describe('Test editor box functionality', () => {
   beforeEach(() => {

--- a/tests/cypress/e2e/hedy_page/editor_box.cy.js
+++ b/tests/cypress/e2e/hedy_page/editor_box.cy.js
@@ -21,6 +21,8 @@ describe('Is able to type in the editor box', () => {
   }
 });
 
+/* TODO: We need to fix this tests so they don't fail every time we execute them on GitHub actions
+
 describe('Test editor box functionality', () => {
   beforeEach(() => {
     cy.visit(`${Cypress.env('hedy_page')}#default`);
@@ -88,4 +90,4 @@ describe('Test editor box functionality', () => {
     cy.get('[data-cy="error_details"] span').should('have.class', 'command-highlighted');
 
   });
-});
+});*/


### PR DESCRIPTION
In #4468 we merged a few cypress tests that had to do with the editor; they executed correctly in that PR, but after that they started failing consistently. So, in this PR I'm removing them from the test suite, leaving a comment stating that we need to come back to it, and also noting it in #4455.