### PR TITLE
[FIX] Fixes Skulpt extensions not working on dev and Alpha

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -127,6 +127,8 @@ export function initializeApp(options: InitializeAppOptions) {
   theLevel = options.level;
   theKeywordLanguage = options.keywordLanguage;
   theStaticRoot = options.staticRoot ?? '';
+  // When we are in Alpha or in dev the static root already points to an internal directory
+  theStaticRoot = theStaticRoot === '/' ? '' : theStaticRoot;
   initializeSyntaxHighlighter({
     keywordLanguage: options.keywordLanguage,
   });


### PR DESCRIPTION
**Description**

Changes the static root from `'/'` to `'' ` when we are in a dev enviroment. The problem was that when we didn't point to a CDN and the contents were delivered from the server the paths looked like this: `//vendor/`  this caused Skulpt not to find those extensions and fail. 

**Fixes #4524**

**How to test**

Try the `clear` or pygame comands.
