### PR TITLE
[FIX] Fix levels in customizations not being set properly

### DIFF
--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -610,7 +610,8 @@ class ForTeachersModule(WebsiteModule):
 
         customizations = self.db.get_class_customizations(class_id)
         dashboard = customizations.get('dashboard_customization', {})
-        levels = dashboard.get('selected_levels', [1])
+        live_statistics_levels = dashboard.get('selected_levels', [1])
+
         customizations = {
             "id": class_id,
             "levels": levels,
@@ -619,7 +620,7 @@ class ForTeachersModule(WebsiteModule):
             "level_thresholds": level_thresholds,
             "sorted_adventures": customizations["sorted_adventures"],
             'dashboard_customization': {
-                'selected_levels': levels
+                'selected_levels': live_statistics_levels
             }
         }
 


### PR DESCRIPTION
**Description**

When storing the customizations settings we where using the same variable for both the levels in the live statistics module, and for the class customizations. Changing that to a use a new variable name fixes the problem.

**How to test**

1. Go to class customizations.
2. Select a few levels and unlock them.
3. Recharge the page

The levels shown should be the ones you selected.

