### PR TITLE
[FIX] Re-enable parser caching

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -11,6 +11,7 @@ import warnings
 import hedy
 import hedy_translation
 from hedy_content import ALL_KEYWORD_LANGUAGES
+import utils
 from collections import namedtuple
 import re
 import regex
@@ -2693,11 +2694,20 @@ def get_keywords_for_language(language):
     return keywords
 
 
+PARSER_CACHE = {}
+
+
 def get_parser(level, lang="en", keep_all_tokens=False):
     """Return the Lark parser for a given level.
     """
+    key = str(level) + "." + lang + '.' + str(keep_all_tokens) + '.' + str(source_map.skip_faulty)
+    existing = PARSER_CACHE.get(key)
+    if existing and not utils.is_debug_mode():
+        return existing
     grammar = create_grammar(level, lang)
-    return Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens)  # ambiguity='explicit'
+    ret = Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens)  # ambiguity='explicit'
+    PARSER_CACHE[key] = ret
+    return ret
 
 
 ParseResult = namedtuple('ParseResult', ['code', 'source_map', 'has_turtle', 'has_pygame'])


### PR DESCRIPTION
Since about a week, the page load times in Hedy have gone up by a lot. My best guess is that the cause is disabling the parser caching in https://github.com/hedyorg/hedy/pull/4504.

This re-enables the parser cache to see if this fixes the load times.

**How to test**

Merge, and eyeball the page load times in Heroku.