### PR TITLE
[CHORE] Record more timings for `/parse` API

### DIFF
--- a/app.py
+++ b/app.py
@@ -473,6 +473,7 @@ def echo_session_vars_main():
 
 
 @app.route('/parse', methods=['POST'])
+@querylog.timed_as('parse_handler')
 def parse():
     body = request.json
     if not body:
@@ -554,10 +555,12 @@ def parse():
         except Exception:
             pass
 
-        try:
-            response['has_sleep'] = 'sleep' in hedy.all_commands(code, level, lang)
-        except BaseException:
-            pass
+        with querylog.log_time('detect_sleep'):
+            try:
+                response['has_sleep'] = 'sleep' in hedy.all_commands(code, level, lang)
+            except BaseException:
+                pass
+
         try:
             if username and not body.get('tutorial') and ACHIEVEMENTS.verify_run_achievements(
                     username, code, level, response):

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -6,6 +6,7 @@ from hedyweb import AchievementTranslations
 from safe_format import safe_format
 from website import database
 from website.auth import current_user, requires_login
+from website import querylog
 
 from .website_module import WebsiteModule, route
 
@@ -99,6 +100,7 @@ class Achievements:
         else:
             return None
 
+    @querylog.timed
     def verify_run_achievements(self, username, code=None, level=None, response=None):
         self.initialize_user_data_if_necessary()
         if session["run_programs"] < self.ACHIEVEMENTS_THRESHOLD:

--- a/website/programs.py
+++ b/website/programs.py
@@ -30,6 +30,7 @@ class ProgramsLogic:
         self.db = db
         self.achievements = achievements
 
+    @querylog.timed
     def store_user_program(self,
                            user,
                            level: int,


### PR DESCRIPTION
Hedy seems to have gotten slower after the deployment of revision `f626e4b1` (previous revision before that: `40ea2878`). There are too many changes in the diff to easily figure out what would have caused that slowdown.

I thought it would be #4504 (which was reverted in #4543) but that didn't clear it up.

Looking into the statistics, it seems that the `/parse` endpoint seems most affected, but the time is NOT spent in transpiling according to the statistics:

```
transpile_ms   duration_ms   method   path
------------   -----------   ------   ------
2143           8769          POST     /parse
1101           5389          POST     /parse
1136           5343          POST     /parse
814            4834          POST     /parse
1045           4820          POST     /parse
2012           4804          POST     /parse
950            4645          POST     /parse
1301           4572          POST     /parse
1141           4505          POST     /parse
4297           4464          POST     /parse
970            4349          POST     /parse
1139           4254          POST     /parse
1710           4252          POST     /parse
777            4203          POST     /parse
1030           4195          POST     /parse
918            4164          POST     /parse
```

As you can see, there's a wide gap between the full duration of handling the request and the `transpile` part of it. 

It's not clear where any of the other time is going; none of the other timers we have in place account for the missing time. In order to figure out where the time is going, I've added more timers in places that feel suspicious to me.

We'll see if that turns anything up, and if not it'll hopefully give us another idea to continue looking.
