### PR TITLE
[CHORE] run snippet generation on changes

### DIFF
--- a/.github/workflows/generate-snippet-hashes.yml
+++ b/.github/workflows/generate-snippet-hashes.yml
@@ -1,37 +1,42 @@
+# Every PR that contains a change to the hash we use in tests/Tester.py
+# should update the hashes file to speed up the unit test CI run.
+
+# We do not do this on PRs as we can not/ do not want to push commits to
+# forked repositories.
+
+# After we merge a PR to main, and it had one of the files affecting
+# snippet generating updated, we make a separate commit that updates the
+# snippet hashes file.
+
 env:
   save_snippet_hashes: True
 
-name: Periodically generate hashes
+name: Generate hashes after every push to main that affects hedy core
 on:
-  schedule:
-    - cron: "0 3 * * *" # Run this job every day at 3am
-  workflow_dispatch: {} # Allow running the workflow on-demand
+  push:
+    branches: ["main"]
+    # these paths should be kept in sync with tests/Tester.py
+    # variable "files_affecting_parsing"
+    paths:
+      - 'grammars/**'
+      - 'hedy.py'
+
 jobs:
   build:
-
+    # Only run this on the main repository where we have HEDY_BOT_TOKEN setup
+    if: github.repository == 'hedyorg/hedy'
     runs-on: ubuntu-latest
-
     steps:
-    - name: Remove existing snippets file # So it does not grow indefinitely
-      uses: JesseTG/rm@v1.0.3
-      with:
-        path: all_snippet_hashes.pkl 
-
-    - name: Checkout branch (with token)
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0    
-        
-        # We need to pass the token here -- the commit action below will not overwrite the token to push.
-        token: ${{ secrets.HEDY_BOT_TOKEN }}
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.9
-    - name: Install Python dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        pip3 install -r requirements.txt
+        cache: 'pip'
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
+    - run: pip install -r requirements.txt
     - name: Install Nodejs dependencies
       run: |
         npm ci
@@ -41,16 +46,18 @@ jobs:
     - name: Compiling Babel translations
       run: |
         pybabel compile -f -d translations
+    - name: Remove existing snippet file
+      run: |
+        rm all_snippet_hashes.pkl
     - name: Run all tests
       run: |
         build-tools/github/validate --all
-        
-    - name: Commit changed files
+    - name: Commit update snippet file
       uses: stefanzweifel/git-auto-commit-action@v4.16.0
       with:
         commit_message: Updating hash files
         commit_author: hedybot <noreply@hedy.org>
-        branch: main
+        file_pattern: all_snippet_hashes.pkl
       env:
         # This is necessary to bypass branch protection (which will disallow non-reviewed pushes otherwise)
         GITHUB_TOKEN: ${{ secrets.HEDY_BOT_TOKEN }}

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -66,6 +66,7 @@ class HedyTester(unittest.TestCase):
         ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         directory = os.path.join(ROOT_DIR, 'grammars')
 
+        # should be kept in sync with .github/workflows/generate-snippet-hashes.yml
         files_affecting_parsing = (
             [os.path.join(directory, filename) for filename in os.listdir(directory)] +
             [os.path.join(ROOT_DIR, 'hedy.py')]


### PR DESCRIPTION
**Description**

Before this change we ran the snippet generation daily. This resulted in commits even when there was no activity. As the snippets file is a bit big and has binary contents, the history of the repository grew a lot.

Now we switch to only updating the hash generation when one of the files that invalidates the entire cache is updated.

We do not do this on PRs as we can not/ do not want to push commits to forked repositories.

After we merge a PR to main, and it had one of the files affecting snippet generating updated, we make a separate commit that updates the snippet hashes file.

**Fixes _issue or discussion number_**

Fixes #4546 .

**How to test**

This is a bit sub-optimal, but you can only test this change with quite some effort (creating a fork etc). However, I did some of these tests already and I think the pragmatic way to test is: read the workflow change critically, see if we agree with the proposed flow, merge it and fix any problem as we go along.

After merging we should check this:
- merge a PR that does NOT affect hedy.py or the grammars -> observe that the action does not run
- also merge a PR that does affect hedy.py or the grammars -> observe that a commit is added after all the tests are executed

**Checklist**
Done? Check if you have it all in place using this list: (mark with x if done)

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section
