### PR TITLE
[FIX] Re-disable parser caching

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -11,7 +11,6 @@ import warnings
 import hedy
 import hedy_translation
 from hedy_content import ALL_KEYWORD_LANGUAGES
-import utils
 from collections import namedtuple
 import re
 import regex
@@ -2609,20 +2608,11 @@ def get_keywords_for_language(language):
     return keywords
 
 
-PARSER_CACHE = {}
-
-
 def get_parser(level, lang="en", keep_all_tokens=False):
     """Return the Lark parser for a given level.
     """
-    key = str(level) + "." + lang + '.' + str(keep_all_tokens) + '.' + str(source_map.skip_faulty)
-    existing = PARSER_CACHE.get(key)
-    if existing and not utils.is_debug_mode():
-        return existing
     grammar = create_grammar(level, lang)
-    ret = Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens)  # ambiguity='explicit'
-    PARSER_CACHE[key] = ret
-    return ret
+    return Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens)  # ambiguity='explicit'
 
 
 ParseResult = namedtuple('ParseResult', ['code', 'source_map', 'has_turtle', 'has_pygame', 'commands'])


### PR DESCRIPTION
Re-disables parser caching, to reduce memory usage.

Originally proposed in #4504, then reverted later in #4543 because we thought it made parse times a lot worse. 

Reverting it didn't make a difference, so the reason for slower parses must have been something else. For that reason, disable caching again, because saving memory is going to allow for more concurrency on a single machine.