### PR TITLE
[FIX] reduce production memory usage by caching parsers to disk

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -11,6 +11,7 @@ from os import path, getenv
 import warnings
 import hedy
 import hedy_translation
+from utils import atomic_write_file
 from hedy_content import ALL_KEYWORD_LANGUAGES
 from collections import namedtuple
 import re
@@ -2641,13 +2642,10 @@ def _save_parser_to_file(lark, pickle_file):
     lark.parser.parser.lexer_conf.re_module = None
     lark.parser.lexer_conf.re_module = None
 
-    with open(full_path + ".tmp", "wb") as fp:
-        pickle.dump(lark, fp)
     try:
-        # atomically rename the temporary file to the final one
-        # to avoid race conditions
-        os.rename(full_path + ".tmp", full_path)
-    except (FileNotFoundError, FileExistsError):
+        with atomic_write_file(full_path) as fp:
+            pickle.dump(lark, fp)
+    except OSError:
         # Ignore errors if another process already moved the file
         # or if the destination already exist.
         # These scenarios can happen under concurrent execution.

--- a/hedy.py
+++ b/hedy.py
@@ -25,6 +25,7 @@ import os
 import pickle
 import sys
 import tempfile
+import utils
 
 # Some useful constants
 from hedy_content import KEYWORDS
@@ -2678,7 +2679,7 @@ def _restore_parser_from_file_if_present(pickle_file):
     return None
 
 
-@lru_cache(maxsize=100)
+@lru_cache(maxsize=0 if utils.is_production() else 100)
 def get_parser(level, lang="en", keep_all_tokens=False, skip_faulty=False):
     """Return the Lark parser for a given level.
     Parser generation takes about 0.5 seconds depending on the level so
@@ -2694,9 +2695,6 @@ def get_parser(level, lang="en", keep_all_tokens=False, skip_faulty=False):
 
     This is not implemented by Lark natively for the Earley parser.
     See https://github.com/lark-parser/lark/issues/1348.
-
-    For now this runs everywhere but we can enable it only in specific
-    environments if desired.
     """
     grammar = create_grammar(level, lang, skip_faulty)
     parser_opts = {

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -79,7 +79,7 @@ def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
         hedy.source_map.clear()
         hedy.source_map.set_skip_faulty(False)
 
-        parser = hedy.get_parser(level, from_lang, True)
+        parser = hedy.get_parser(level, from_lang, True, hedy.source_map.skip_faulty)
         keyword_dict_from = keywords_to_dict(from_lang)
         keyword_dict_to = keywords_to_dict(to_lang)
 
@@ -134,7 +134,7 @@ def replace_token_in_line(line, rule, original, target):
 def find_command_keywords(
     input_string, lang, level, keywords, start_line, end_line, start_column, end_column
 ):
-    parser = hedy.get_parser(level, lang, True)
+    parser = hedy.get_parser(level, lang, True, hedy.source_map.skip_faulty)
     program_root = parser.parse(input_string).children[0]
 
     translator = Translator(input_string)


### PR DESCRIPTION
## Description

Implement a disk based caching system for the parsers. They take about
0.5 seconds to be constructed which leads to delays and high CPU usage.

We used to cache to RAM but now needed multiple GBs of RAM for all the
parsers. The servers don't like this.

With this PR we cache to disk, by pickling the parsers.

NOTE: this PR contains a commit which belongs in #4574 but was needed for this change too. If it gets merged the commit can be dropped from this PR.

## Link to issue

Discussed this in PR #4576 .

## How to test

- See all CI tests succeeding
- Run the entire pytest suite without this fix locally and observe a +/- 1.5GB memory footprint.
- Run with this patch and see that it should only uses about 400MB, while being roughly as fast to execute
- After deployment to production there should be less out of memory issues.

## Checklist
Done? Check if you have it all in place using this list: (mark with x if done)

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section
