### PR TITLE
[FIX] fix the github workflow for generating snippet hashes

### DIFF
--- a/.github/workflows/generate-snippet-hashes.yml
+++ b/.github/workflows/generate-snippet-hashes.yml
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # We _really_ need to pass the token here -- the commit action below
+        # will not overwrite the token to push. We removed it in
+        # 82fd39a9e215246a37f652aef416bb1600d849db and it failed badly.
+        token: ${{ secrets.HEDY_BOT_TOKEN }}
     - uses: actions/setup-python@v3
       with:
         python-version: 3.9


### PR DESCRIPTION
**Description**

After my attempt to make the snippet generation change-based in #4573 there's good news and bad news. The good is that the trigger works, and a PR that had a new `hedy.py` file triggered the snippet generation. The bad news is that the automatic commit action failed due to a permission issue.

https://github.com/hedyorg/hedy/actions/runs/6409135403/job/17399693158

Reading the workflow logic this does not make sense to me and feels like a bug in the git-auto-commit-action but it is what it is :shrug: . As we had no simple way of testing this we decided to merge anyway and solve problems as we go along. This fixes the issue.

**How to test**

- merge this and see if the next change to grammars and/or hedy.py manages to commit the snippet hashes correctly.

**Checklist**

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
