### PR TITLE
[FIX] Generalize the fix for quotes in french exception messages

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -174,6 +174,16 @@ def needs_colon(rule):
     return f'{rule[0:pos]} _COLON {rule[pos:]}'
 
 
+def _translate_index_error(code, list_name):
+    exception_text = gettext('catch_index_exception').replace('{list_name}', style_command(list_name))
+    return textwrap.dedent(f"""\
+        try:
+          {code}
+        except IndexError:
+          raise Exception({repr(exception_text)})
+        """)
+
+
 PREPROCESS_RULES = {
     'needs_colon': needs_colon
 }
@@ -1493,17 +1503,8 @@ class ConvertToPython_1(ConvertToPython):
                     list_args.append(group[3])
                     lists_names.append(group[4])
         code = ""
-        exception_text_template = gettext('catch_index_exception')
         for i, list_name in enumerate(lists_names):
-            exception_text = exception_text_template.replace('{list_name}', style_command(list_name))
-            if "'" in exception_text:
-                exception_text = exception_text.replace("'", "\\'")
-            code += textwrap.dedent(f"""\
-            try:
-              {list_args[i]}
-            except IndexError:
-              raise Exception('{exception_text}')
-            """)
+            code += _translate_index_error(list_args[i], list_name)
         return code
 
 
@@ -2312,13 +2313,7 @@ class ConvertToPython_16(ConvertToPython_15):
     def change_list_item(self, meta, args):
         left_side = args[0] + '[' + args[1] + '-1]'
         right_side = args[2]
-        exception_text = gettext('catch_index_exception').replace('{list_name}', style_command(args[0]))
-        exception = textwrap.dedent(f"""\
-        try:
-          {left_side}
-        except IndexError:
-          raise Exception('{exception_text}')
-        """)
+        exception = _translate_index_error(left_side, args[0])
         return exception + left_side + ' = ' + right_side
 
     def ifs(self, meta, args):


### PR DESCRIPTION
**Description**

In French, it is common to have quotes in messages, this commit generalizes the correction that has been done at level 1 but that was also present at level 16.

If you tried the following code at level 16, you had the same error as the one reported by the issue #4610 instead of having a nice error message

```
fruit = []
fruit[1] = "pomme"
```

<img width="752" alt="Capture d’écran 2023-10-14 à 15 26 29" src="https://github.com/hedyorg/hedy/assets/298214/f97786df-68cc-49a3-ad63-bb9aa54780c9">


**Adds** I created the function `translate_index_error` responsible for translating a possible IndexError exception and escaping all possible quotes in the error message.

Being new to Hedy, I did not really know where to put that utilities function. Please give me any instruction in the comments.

**Fixes #4610**

**How to test**

Run the following code in French, at level 16 : 

```
fruits = []
fruits[1] = "pomme"
```

The reported error message should be: 
`Tu as essayé d'accéder à la liste fruits, celle-ci est vide ou sans index.`
instead of
`bad input`

**Checklist**

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section