### PR TITLE
[CHORE] Reverting teststring

### DIFF
--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1850,9 +1850,6 @@ msgstr "Your personal text..."
 msgid "your_program"
 msgstr "Your program"
 
-msgid "test_string"
-msgstr "Test string"
-
 #~ msgid "create_account_explanation"
 #~ msgstr "Having your own account allows you to save your programs."
 


### PR DESCRIPTION
PR #4613 was created last week. This contained just a teststring in the Englisch po file to see how Weblate handled the automatich filling of other languages and squashing those changes into one commit.
This worked fine, hence this PR removes the teststring again.