### PR TITLE
Allow embedding host to toggle readonly mode

### DIFF
--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -136,7 +136,6 @@
 
             // Listen to message from the host to dynamically toggle readOnly mode
             window.addEventListener('message', function (message) {
-                console.log(message);
                 if (message.data.mode) {
                     const editor = ace.edit('editor');
                     if (message.data.mode == 'read') {

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -124,9 +124,9 @@
             })
 
             // Remove all console logs as these messages might clutter the log of the parent site
-            // console.log = function () {};
-            // console.dir = function () {};
-            // console.debug = function () {};
+            console.log = function () {};
+            console.dir = function () {};
+            console.debug = function () {};
 
             // Dynamically add the gutter to the editor when readOnly
             {% if readOnly %}
@@ -139,9 +139,9 @@
                 if (message.data.mode) {
                     const editor = ace.edit('editor');
                     if (message.data.mode == 'readonly') {
-                        editor.setOption("readonly", true);
+                        editor.setReadOnly(true);
                     } else if (message.data.mode == 'edit') {
-                        editor.setOption("readonly", false);
+                        editor.setReadOnly(false);
                     }
                 }
             });

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -136,9 +136,10 @@
 
             // Listen to message from the host to dynamically toggle readOnly mode
             window.addEventListener('message', function (message) {
+                console.log(message);
                 if (message.data.mode) {
                     const editor = ace.edit('editor');
-                    if (message.data.mode == 'readonly') {
+                    if (message.data.mode == 'read') {
                         editor.setReadOnly(true);
                     } else if (message.data.mode == 'edit') {
                         editor.setReadOnly(false);

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -124,15 +124,27 @@
             })
 
             // Remove all console logs as these messages might clutter the log of the parent site
-            console.log = function () {};
-            console.dir = function () {};
-            console.debug = function () {};
+            // console.log = function () {};
+            // console.dir = function () {};
+            // console.debug = function () {};
 
             // Dynamically add the gutter to the editor when readOnly
             {% if readOnly %}
-                var editor = ace.edit('editor');
+                const editor = ace.edit('editor');
                 editor.setOption("showGutter", true);
             {% endif %}
+
+            // Listen to message from the host to dynamically toggle readOnly mode
+            window.addEventListener('message', function (message) {
+                if (message.data.mode) {
+                    const editor = ace.edit('editor');
+                    if (message.data.mode == 'readonly') {
+                        editor.setOption("readonly", true);
+                    } else if (message.data.mode == 'edit') {
+                        editor.setOption("readonly", false);
+                    }
+                }
+            });
 
             // We need a work-around to allow listening to events from outside the embedded editor
             function sendRunEvent() {


### PR DESCRIPTION
**Description**
This is a small improvement to the embedded editor to listen to messages from the host page. In this case allow to dynamically toggle the readonly state of the editor. Something that can be useful for several use-cases.