### PR TITLE
[FIX] Fix the `filtered_programs_for_user` call

### DIFF
--- a/app.py
+++ b/app.py
@@ -954,7 +954,7 @@ def programs_page(user):
     filter = request.args.get('filter', default=None, type=str)
     submitted = True if filter == 'submitted' else None
 
-    result = DATABASE.filtered_programs_for_user({"username": from_user or username},
+    result = DATABASE.filtered_programs_for_user(from_user or username,
                                                  level=level,
                                                  adventure=adventure,
                                                  submitted=submitted,
@@ -1756,7 +1756,7 @@ def reset_page():
 @requires_login_redirect
 def profile_page(user):
     profile = DATABASE.user_by_username(user['username'])
-    programs = DATABASE.filtered_programs_for_user({"username": user['username'], "public": 1})
+    programs = DATABASE.public_programs_for_user(user['username'])
     public_profile_settings = DATABASE.get_public_profile_settings(current_user()['username'])
 
     classes = []
@@ -2371,9 +2371,9 @@ def public_user_page(username):
     user_public_info = DATABASE.get_public_profile_settings(username)
     page = request.args.get('page', default=None, type=str)
     if user_public_info:
-        user_programs = DATABASE.filtered_programs_for_user({"username": user['username'], "public": 1},
-                                                            limit=10,
-                                                            pagination_token=page)
+        user_programs = DATABASE.public_programs_for_user(username,
+                                                          limit=10,
+                                                          pagination_token=page)
         next_page_token = user_programs.next_page_token
         user_programs = normalize_public_programs(user_programs)
         user_achievements = DATABASE.progress_by_username(username) or {}

--- a/app.py
+++ b/app.py
@@ -1756,7 +1756,7 @@ def reset_page():
 @requires_login_redirect
 def profile_page(user):
     profile = DATABASE.user_by_username(user['username'])
-    programs = DATABASE.public_programs_for_user(user['username'])
+    programs = DATABASE.filtered_programs_for_user(user['username'], public=True)
     public_profile_settings = DATABASE.get_public_profile_settings(current_user()['username'])
 
     classes = []
@@ -2371,9 +2371,10 @@ def public_user_page(username):
     user_public_info = DATABASE.get_public_profile_settings(username)
     page = request.args.get('page', default=None, type=str)
     if user_public_info:
-        user_programs = DATABASE.public_programs_for_user(username,
-                                                          limit=10,
-                                                          pagination_token=page)
+        user_programs = DATABASE.filtered_programs_for_user(username,
+                                                            public=True,
+                                                            limit=10,
+                                                            pagination_token=page)
         next_page_token = user_programs.next_page_token
         user_programs = normalize_public_programs(user_programs)
         user_achievements = DATABASE.progress_by_username(username) or {}

--- a/website/database.py
+++ b/website/database.py
@@ -198,7 +198,7 @@ class Database:
         """
         return PROGRAMS.get_many({"username": username}, reverse=True)
 
-    def filtered_programs_for_user(self, username, level=None, adventure=None, submitted=None,
+    def filtered_programs_for_user(self, username, level=None, adventure=None, submitted=None, public=None,
                                    limit=None, pagination_token=None):
         ret = []
 
@@ -218,25 +218,12 @@ class Database:
             if submitted is not None:
                 if program.get('submitted') != submitted:
                     continue
+            if public is not None and bool(program.get('public')) != public:
+                continue
 
             ret.append(program)
 
             if limit and len(ret) >= limit:
-                break
-
-        return dynamo.ResultPage(ret, programs.next_page_token)
-
-    def public_programs_for_user(self, username, limit=None, pagination_token=None):
-        # Only return programs that are public but not submitted
-        programs = dynamo.GetManyIterator(PROGRAMS, {"username": username},
-                                          reverse=True, batch_size=limit, pagination_token=pagination_token)
-        ret = []
-        for program in programs:
-            if program.get("public") != 1 or program.get("submitted", False):
-                continue
-            ret.append(program)
-
-            if limit is not None and len(ret) >= limit:
                 break
 
         return dynamo.ResultPage(ret, programs.next_page_token)

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -222,12 +222,13 @@ class ForTeachersModule(WebsiteModule):
         filter = request.args.get('filter', default=None, type=str)
         submitted = True if filter == 'submitted' else None
 
-        result = self.db.public_programs_for_user(from_user,
-                                                  level=level,
-                                                  adventure=adventure,
-                                                  submitted=submitted,
-                                                  pagination_token=page,
-                                                  limit=10)
+        result = self.db.filtered_programs_for_user(from_user,
+                                                    level=level,
+                                                    adventure=adventure,
+                                                    submitted=submitted,
+                                                    pagination_token=page,
+                                                    public=True,
+                                                    limit=10)
 
         programs = []
         for item in result:

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -222,12 +222,12 @@ class ForTeachersModule(WebsiteModule):
         filter = request.args.get('filter', default=None, type=str)
         submitted = True if filter == 'submitted' else None
 
-        result = self.db.filtered_programs_for_user({"username": from_user, "public": 1},
-                                                    level=level,
-                                                    adventure=adventure,
-                                                    submitted=submitted,
-                                                    pagination_token=page,
-                                                    limit=10)
+        result = self.db.public_programs_for_user(from_user,
+                                                  level=level,
+                                                  adventure=adventure,
+                                                  submitted=submitted,
+                                                  pagination_token=page,
+                                                  limit=10)
 
         programs = []
         for item in result:


### PR DESCRIPTION
In #4644, the call signature of `filtered_programs_for_user` was changed to replace the function `public_programs_for_user`. The goal was to be able to supply the query `get_many({ "username": "henk", "public": 1 })`, with the goal to retrieve all public programs by user `henk`.

Unfortunately, there is no index on the pair `(username, public)`. Instead, we have indexes on `(username)` and on `(public, date)`.

The first is used to retrieve all programs by a single user, the second is used to retrieve all public programs (for the "Explore" page). To get the public programs for a single user, instead what we do is retrieve all programs for a single user, and filter them down in Python.

Because of a bug in the database layer, trying to retrieve programs by `{ "username": "henk", "public": 1 }` uses the `(public, date)` index. However, the database layer does not detect that in that particular query the field `date` is missing, and that the field `username` is unnecessarily passed. The query incorrectly succeeds in the local database emulation mode so this goes undetected during testing, and when passed to an actual DynamoDB database the server returns an error.

This currently breaks the profile page, as well as some other pages probably.

Add `public` as an optional keyword argument to `filtered_programs_for_user` and do the filtering locally instead.

**How to test**

The following pages should work:

* `/my-profile`
* `/programs`
* `/class/<class_id>/programs/<username>`
