### PR TITLE
[FIX, TESTING] Fixes failing teacher test

### DIFF
--- a/tests/cypress/e2e/for-teacher_page/class_page/second_teachers_invites.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/second_teachers_invites.cy.js
@@ -1,30 +1,26 @@
 import {loginForTeacher, logout} from "../../tools/login/login.js"
 import { goToProfilePage } from "../../tools/navigation/nav";
+import { createClass } from "../../tools/classes/class";
 
 const secondTeachers = ["teacher2", "teacher3"]
 const invitesTable = body => body.find("#invites-block table")
 
 describe("Second teachers: invitations", () => {
-  it(`Invites ${secondTeachers.length} second teachers: by username`, () => {
-
+  before(() => {
     loginForTeacher();
+    createClass()
+  });
 
-    cy.wait(500);
-
+  it(`Invites ${secondTeachers.length} second teachers: by username`, () => {
+    loginForTeacher();
     cy.get(".view_class").first().click();
     cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
 
     for (const teacher of secondTeachers) {
-      cy.wait(500);
       
       cy.get("#add-second-teacher").click();
-      
-      // cy.get("#invite-student").click();
-      // cy.wait(2000)
       cy.get("#modal-prompt-input").type(teacher);
       cy.get("#modal-ok-button").click();
-      
-      cy.wait(500);
       
       cy.get("body").then(invitesTable).then(table => {
         if (table.length) {
@@ -37,24 +33,15 @@ describe("Second teachers: invitations", () => {
         }
       })
     }
-      //logout:
-    // logout();
   })
 
   it(`Tries duplicating ${secondTeachers[0]}'s invitation`, () => {
-
-    loginForTeacher()
-
+    loginForTeacher();
     cy.get(".view_class").first().click();
-    cy.wait(500);
-    cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
-
-    cy.wait(500);
 
     cy.get("#add-second-teacher").click();
     cy.get("#modal-prompt-input").type(secondTeachers[0]);
     cy.get("#modal-ok-button").click();
-    cy.wait(500);
 
     cy.get("#modal_alert_container")
     .should('be.visible')
@@ -66,26 +53,18 @@ describe("Second teachers: invitations", () => {
     goToProfilePage()
     cy.get("#messages").should("exist")
     cy.get("#messages #join").click()
-    logout();
   })
 
   it("Reads all second teachers", () => {
     loginForTeacher()
-    cy.get(".view_class").first().click();
-    cy.wait(500);
-    cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
+    cy.get(".view_class").first().click();        
     cy.get("#second_teachers_container .username_cell").should("include.text", secondTeachers[0])
-    logout()
   })
 
   it(`Deletes ${secondTeachers[1]}'s invitation`, () => {
 
     loginForTeacher();
-    cy.wait(500);
     cy.get(".view_class").first().click();
-    cy.wait(500);
-    cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
-
     cy.get("body").then(invitesTable).then(table => {
       // if not, then no invitation.
       if (table.length) {
@@ -93,17 +72,13 @@ describe("Second teachers: invitations", () => {
         console.log(table)
         table.should("exist")
         table.get(".remove_user_invitation").first().click()
-        cy.wait(500);
         cy.get("#modal-yes-button").click();
       } else {
         cy.log("Second teacher not deleted.")
       }
     })
-    
-    cy.wait(500);
     cy.get('body').then(invitesTable).then(table => 
       table.length && cy.get("#invites-block table").should("not.contain", secondTeachers[0]))
-    logout();
   })
 
 })

--- a/tests/cypress/e2e/for-teacher_page/class_page/second_teachers_invites.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/class_page/second_teachers_invites.cy.js
@@ -14,7 +14,6 @@ describe("Second teachers: invitations", () => {
   it(`Invites ${secondTeachers.length} second teachers: by username`, () => {
     loginForTeacher();
     cy.get(".view_class").first().click();
-    cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
 
     for (const teacher of secondTeachers) {
       


### PR DESCRIPTION
**Description**

The first test in the file `second_teacher_invites` was failing because the survey was getting on the way. This PR fixes it by creating a new class before all the tests are executed, and since this new class doesn't have any students we guarantee that the survey is not shown. This approach should be applied to all the other tests, I think, but this one is a bit more urgent since it's not letting us merge PRs
