### PR TITLE
[BUG] Allow users to navigate between exercises using header

### DIFF
--- a/static/css/additional.css
+++ b/static/css/additional.css
@@ -196,3 +196,8 @@ body[dir='rtl'] #editor .ace_gutter-layer > * {
   bottom: 1px;
   right: 3px;
 }
+
+.current {
+  font-weight: bold;
+  background-color: #edf2f7;
+}

--- a/static/js/index.ts
+++ b/static/js/index.ts
@@ -23,3 +23,4 @@ export * from './browser-helpers/unsaved-changes';
 export * from './initialize';
 export * from './debugging';
 export { getPreviousAndNext } from './tabs';
+export { loadParsonsExercise } from './parsons';

--- a/templates/incl/editor-and-output.html
+++ b/templates/incl/editor-and-output.html
@@ -55,11 +55,11 @@
         <div id="editor" style="background: #272822; font-size:0.95em; color: white; direction: {{ g.dir }};" lang="en" blurred='false'
           {% if editor_readonly %}data-readonly="true"{% endif %}
           class="w-full flex-1 text-lg rounded {% if raw %} max-h-56 {% endif %}"></div>
-        <div id="parsons_code_container" class="w-full flex flex-col mx-auto gap-2 items-center" style="display: none;">
+        <div id="parsons_code_container" class="w-full flex flex-col mx-auto gap-2 items-center hover:cursor" style="display: none;">
             {% for i in range(1, 11) %}
-                <div class="turn-pre-into-ace relative w-full border-4 border-black rounded-lg parsons_goal_line_container" style="background-color: #272822;" id="parsons_goal_line_container_{{ i }}">
+                <div class="turn-pre-into-ace relative w-full p-2 border-4 border-black rounded-lg parsons_goal_line_container cursor-grab" style="background-color: #272822;" id="parsons_goal_line_container_{{ i }}">
                     <div index="-" draggable="true" code="" class="compiler-parsons-box w-full absolute inset-0 z-10 rounded-lg"></div>
-                    <pre level="{{ level }}" id="goal_parsons_{{ i }}" class="goal_parsons parsons text-sm"></pre>
+                    <pre level="{{ level }}" id="goal_parsons_{{ i }}" class="goal_parsons parsons text-sm m-0"></pre>
                 </div>
             {% endfor %}
         </div>

--- a/templates/incl/parsons.html
+++ b/templates/incl/parsons.html
@@ -1,12 +1,14 @@
 <div id="parsons_container" class="hidden">
     {% if parsons_exercises > 1 %}
-        <div class="flex flex-row items-center justify-around gap-2 border-b-2 border-gray-500 pb-2">
+        <div class="flex flex-row items-center justify-around bg-gray-400 border-b-2 border-gray-500">
             {% for i in range(1, parsons_exercises + 1)%}
-                {% if i == 1 %}
-                 <div class="step current bg-gray-200" id="parsons_header_{{i}}"><span class="parsons_header_text_container" id="parsons_header_text_{{i}}">{{_('exercise')}}</span> {{ i }}</div>
-                {% else %}
-                    <div class="step {% if i % 2 == 0 %}bg-gray-400{% else %}bg-gray-200{% endif %}" id="parsons_header_{{i}}"><span class="parsons_header_text_container" id="parsons_header_text_{{i}}" style="display: none;">{{_('exercise')}}</span> {{ i }}</div>
-                {% endif %}
+                    <div class="flex-1 text-center step cursor-pointer p-2
+                        {% if i != parsons_exercises %}border-dashed border-r border-gray-500{% endif %}
+                    " id="parsons_header_{{i}}"
+                        _="on click hedyApp.loadParsonsExercise({{level}}, {{i}})">
+                        <span class="parsons_header_text_container" id="parsons_header_text_{{i}}" style="display: none;">{{_('exercise')}}</span> 
+                        {{ i }}
+                    </div>
             {% endfor %}
         </div>
     {% endif %}
@@ -16,9 +18,9 @@
                 <p id="parsons_explanation_text"></p>
                 <div class="flex flex-col mx-auto gap-2 items-center" id="parsons_code_lines">
                     {% for i in range(1, 11) %}
-                        <div class="relative w-full border-4 border-black rounded-lg parsons_start_line_container" style="background-color: #272822;" id="parsons_start_line_container_{{ i }}">
+                        <div class="relative w-full p-2 border-4 border-black rounded-lg parsons_start_line_container cursor-grab" style="background-color: #272822;" id="parsons_start_line_container_{{ i }}">
                             <div index="" draggable="true" id="start_parsons_div_{{ i }}" code="" class="start-parsons-box w-full absolute inset-0 z-10 rounded-lg"></div>
-                            <pre level="{{ level }}" id="start_parsons_{{ i }}" class="no-copy-button parsons text-sm"></pre>
+                            <pre level="{{ level }}" id="start_parsons_{{ i }}" class="no-copy-button parsons text-sm m-0"></pre>
                         </div>
                     {% endfor %}
                 </div>


### PR DESCRIPTION
Fixes #4441 

Enhanced the overall ui of exercises.  
- Better header;  
  - Clear background and font weight on the currently selected exercise 
  - Also, users now can click to navigate through existing exercises 
- Next button doesn't show currenlty. 
  - Hiding it always is fine, since navigation is possible using the headers. 

**How to test**
- see #4441 or simply view the puzzles..