### PR TITLE
[UI, FIX] Fixes placing of checkbox and eye icon on grid

### DIFF
--- a/templates/customize-grid/partial-grid-levels.html
+++ b/templates/customize-grid/partial-grid-levels.html
@@ -20,17 +20,27 @@
             {% set adventure_id = adventure_names[class_adventures[level][adventure_index]] %}
             {% set student_adventure_id = student ~ '-' ~ adventure_id ~ '-' ~ level %}
             {% if checkbox is not none %}
-              <td class="p-2 border-gray-400 {% if not loop.last %}border-r{% endif %} {% if not is_last_student %}border-b{% endif %}">
-                <div class="relative">
-                  <input type="checkbox" 
-                         name="gridCheckBox" 
-                         class="student_adventure_checkbox align-middle text-green-700 text-center text-sm cursor-pointer {% if checkbox == 1%}fa-solid fa-check{% endif %}" 
-                         {% if checkbox == 1%}checked{% endif %} 
-                         hx-post="/grid_overview/class/{{ class_info.id }}/level?level={{ level }}&student_index={{ student_index }}&adventure_index={{ adventure_index }}" 
-                         hx-target="#level" 
-                         hx-swap="outerHTML" 
-                         hx-trigger="change">           
-                         <a class="no-underline cursor-pointer absolute right-0 text-gray-800 hover:bg-gray-400/50 hover:rounded-full px-2 mx-0" href='/hedy/{{student_adventures[student_adventure_id]}}/view'><i class="fa-regular fa-eye"></i></a>
+              <td
+                class="p-2 border-gray-400
+                      {% if not loop.last %}border-r{% endif %}
+                      {% if not is_last_student %}border-b{% endif %}"
+              >              
+                <div class="grid grid grid-cols-[repeat(3,_minmax(25px,_1fr))] gap-3">
+                  {# Empty div so there's  gap to the middle and then the eye #}
+                  <div></div>
+                  <div>
+                    <input type="checkbox" 
+                            name="gridCheckBox"                            
+                            class="student_adventure_checkbox min-w-fit place-self-center text-green-700 text-center text-sm cursor-pointer {% if checkbox == 1%}fa-solid fa-check{% endif %}" 
+                            {% if checkbox == 1%}checked{% endif %} 
+                            hx-post="/grid_overview/class/{{ class_info.id }}/level?level={{ level }}&student_index={{ student_index }}&adventure_index={{ adventure_index }}" 
+                            hx-target="#level" 
+                            hx-swap="outerHTML" 
+                            hx-trigger="change">           
+                  </div>
+                  <div>
+                    <a class="no-underline cursor-pointer text-gray-800 hover:bg-gray-400/50 hover:rounded-full" href='/hedy/{{student_adventures[student_adventure_id]}}/view'><i class="fa-regular fa-eye"></i></a>
+                  </div>
                 </div>
               </td>
             {% else %}


### PR DESCRIPTION
**Description**

Changes the table elements to be each a table layout of 3 columns, where the first column is empty, for alignment, the second one is the checkbox and the third one is the eye. This fixes the overflowing behavior that the elements of this table presented.

Worth noting that this page will be moved from here to the dashboard, but we need this fix shipped because it's very annoying!

**Fixes [this comment](https://github.com/hedyorg/hedy/issues/4580#issuecomment-1803884643) on #4580**

**How to test**

* Make sure that some students have adventures done for a particular class.
* Go to the class and click on Overview of programs per adventure.
* Zoom-in and out and see that the elements do not overflow or mess with each other 