### PR TITLE
[BUG] Fix broken tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,8 +149,9 @@ logs.txt
 .local
 node_modules
 
-# Ignore things that start with underscores
+# Ignore things that start with underscores (except __init__.py)
 _*
+!__init__.py
 # Ignore pickled versions of YAML files
 *.yaml.pickle
 dev_database.json

--- a/hedy.py
+++ b/hedy.py
@@ -2961,7 +2961,7 @@ def transpile(input_string, level, lang="en", skip_faulty=True, is_debug=False):
     except Exception as original_error:
         hedy_amount_lines = len(input_string.strip().split('\n'))
 
-        if getenv('ENABLE_SKIP_FAULTY', True) and skip_faulty and hedy_amount_lines > 1:
+        if getenv('ENABLE_SKIP_FAULTY', False) and skip_faulty and hedy_amount_lines > 1:
             if isinstance(original_error, source_map.exceptions_not_to_skip):
                 raise original_error
             try:

--- a/hedy.py
+++ b/hedy.py
@@ -2961,7 +2961,7 @@ def transpile(input_string, level, lang="en", skip_faulty=True, is_debug=False):
     except Exception as original_error:
         hedy_amount_lines = len(input_string.strip().split('\n'))
 
-        if getenv('ENABLE_SKIP_FAULTY', False) and skip_faulty and hedy_amount_lines > 1:
+        if getenv('ENABLE_SKIP_FAULTY', True) and skip_faulty and hedy_amount_lines > 1:
             if isinstance(original_error, source_map.exceptions_not_to_skip):
                 raise original_error
             try:
@@ -3347,7 +3347,6 @@ def create_lookup_table(abstract_syntax_tree, level, lang, input_string):
 
 
 def create_AST(input_string, level, lang="en"):
-    input_string = process_input_string(input_string, level, lang)
     program_root = parse_input(input_string, level, lang)
 
     try:
@@ -3377,6 +3376,7 @@ def create_AST(input_string, level, lang="en"):
 
 def transpile_inner(input_string, level, lang="en", populate_source_map=False, is_debug=False):
     check_program_size_is_valid(input_string)
+    input_string = process_input_string(input_string, level, lang)
 
     level = int(level)
     if level > HEDY_MAX_LEVEL:

--- a/tests/test_level/test_level_05.py
+++ b/tests/test_level/test_level_05.py
@@ -186,31 +186,30 @@ class TestsLevel5(HedyTester):
             max_level=7
         )
 
-    # Disabled in 4838
-    # def test_if_equality_unquoted_rhs_with_space_and_following_command_print_gives_error(self):
-    #     code = textwrap.dedent("""\
-    #     naam is James
-    #     if naam is James Bond print 'shaken'
-    #     print naam
-    #     prind skipping""")
-    #
-    #     expected = textwrap.dedent("""\
-    #     naam = 'James'
-    #     pass
-    #     print(f'{naam}')
-    #     pass""")
-    #
-    #     skipped_mappings = [
-    #         SkippedMapping(SourceRange(2, 1, 2, 59), hedy.exceptions.UnquotedEqualityCheckException),
-    #         SkippedMapping(SourceRange(4, 1, 4, 15), hedy.exceptions.InvalidCommandException)
-    #     ]
-    #
-    #     self.multi_level_tester(
-    #         code=code,
-    #         expected=expected,
-    #         skipped_mappings=skipped_mappings,
-    #         max_level=7
-    #     )
+    def test_if_equality_unquoted_rhs_with_space_and_following_command_print_gives_error(self):
+        code = textwrap.dedent("""\
+        naam is James
+        if naam is James Bond print 'shaken'
+        print naam
+        prind skipping""")
+
+        expected = textwrap.dedent("""\
+        naam = 'James'
+        pass
+        print(f'{naam}')
+        pass""")
+
+        skipped_mappings = [
+            SkippedMapping(SourceRange(2, 1, 2, 58), hedy.exceptions.UnquotedEqualityCheckException),
+            SkippedMapping(SourceRange(4, 1, 4, 15), hedy.exceptions.InvalidCommandException)
+        ]
+
+        self.multi_level_tester(
+            code=code,
+            expected=expected,
+            skipped_mappings=skipped_mappings,
+            max_level=7
+        )
 
     def test_if_equality_unquoted_rhs_with_space_assign_gives_error(self):
         code = textwrap.dedent("""\

--- a/tests/test_level/test_level_07.py
+++ b/tests/test_level/test_level_07.py
@@ -170,25 +170,24 @@ class TestsLevel7(HedyTester):
             exception=hedy.exceptions.IncompleteRepeatException
         )
 
-    # Disabled in 4838
-    # def test_repeat_with_missing_times_gives_error_skip(self):
-    #     code = textwrap.dedent("""\
-    #     x is 3
-    #     repeat 3 print 'x'""")
-    #
-    #     expected = textwrap.dedent("""\
-    #     x = '3'
-    #     pass""")
-    #
-    #     skipped_mappings = [
-    #         SkippedMapping(SourceRange(2, 1, 2, 17), hedy.exceptions.IncompleteRepeatException),
-    #     ]
-    #
-    #     self.single_level_tester(
-    #         code=code,
-    #         expected=expected,
-    #         skipped_mappings=skipped_mappings,
-    #     )
+    def test_repeat_with_missing_times_gives_error_skip(self):
+        code = textwrap.dedent("""\
+        x is 3
+        repeat 3 print 'x'""")
+
+        expected = textwrap.dedent("""\
+        x = '3'
+        pass""")
+
+        skipped_mappings = [
+            SkippedMapping(SourceRange(2, 1, 2, 19), hedy.exceptions.IncompleteRepeatException),
+        ]
+
+        self.single_level_tester(
+            code=code,
+            expected=expected,
+            skipped_mappings=skipped_mappings,
+        )
 
     def test_repeat_with_missing_print_gives_lonely_text_exc(self):
         code = textwrap.dedent("""\


### PR DESCRIPTION
Fixes #4863.

After #4838, the processing of the string was done after setting the input string on the source map.
This led to 2 tests failing.

This PR first uses process_input_string before setting the input on the source map. Fixing the failing tests.