### PR TITLE
[CONTENT] Restores deleted content

### DIFF
--- a/content/adventures/en.yaml
+++ b/content/adventures/en.yaml
@@ -4156,6 +4156,67 @@ adventures:
                         {turn} _
                         {forward} _
                     ``
+            9:
+                story_text: |
+                    Now that we can use a `{repeat}` inside a `{repeat}`, we can create more complex figures.
+
+                    ### Exercise 1
+                    This code creates three black triangles, change that into five pink squares.
+
+                     **Extra** Create a figure of your own choosing consisting of at least two different shapes types.
+                example_code: |
+                    ```
+                    {color} {black}
+                    {repeat} 3 {times}
+                        {repeat} 3 {times}
+                            {forward} 10
+                            {turn} 120
+                        {color} {white}
+                        {forward} 50
+                        {color} {black}
+                    ```
+            10:
+                story_text: |
+                    In this level you can make the turtle draw a figure.
+                    The turtle will travel the distances in the list, one by one, making bigger and bigger steps.
+                    ### Exercise 1
+                    Add a 90 degree turn in the loop, so that a spiral is drawn.
+                    Add at least 5 numbers to the list, so the spiral grows larger.
+                    **(extra)** can you change the spiral into another shape? Experiment with numbers for the turn!
+                    ### Exercise 2
+                    The spiral is drawn outwards, make it go inwards?
+                example_code: |
+                    ```
+                    {turn} 90
+                    distances = 10, 20, 30, 40, 50, 60
+                    {for} distance {in} distances
+                        {forward} distance
+                    ```
+                    ```
+            12:
+                story_text: |
+                    We can use functions to draw more complex figures with less code.
+                    ### Exercise 1
+                    Fill the function so that three squares are created. If you want the image to look nicer, you can make the lines between the squares white.
+
+                    ### Exercise 2
+                    The code can be made even shorter. Place the final lines into a `{repeat}` so the figure remains the same.
+
+                    ### Exercise 3
+                    Create your own drawing with different figures.
+                    Change both the number of figures with the `{repeat}` and the shape of the figures in the `{define}`
+                example_code: |
+                    ```
+                    {define} square
+                        {repeat} 4 {times}
+                            {turn} _
+                            {forward} _
+                    {call} square
+                    {forward} 50
+                    {call} square
+                    {forward} 50
+                    {call} square
+                    ```
     turtle_draw_it:
         name: Draw it!
         default_save_name: Draw it

--- a/tests/cypress/e2e/for-teacher_page/customize-adventure_page/level_field.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/customize-adventure_page/level_field.cy.js
@@ -1,34 +1,34 @@
 import {loginForTeacher} from '../../tools/login/login.js'
 import {goToEditAdventure} from '../../tools/navigation/nav.js'
 
-//describe('Levels Dropdown Select test', () => {
-//  const levels = ["3", "5"];
-//  for (const level of levels) {
-//    for (const teacher of ["teacher1", "teacher4"]) {
-//      it(`${teacher} can select level ${level}`, () => {
-//        loginForTeacher(teacher);
-//        goToEditAdventure();
-//
-//        // Tests level field interaction
-//        cy.get('#custom_adventure_levels_container')
-//          .should('be.visible')
-//          .should('not.be.disabled')
-//          .click()
-//
-//        cy.wait(400)
-//
-//        cy.get("div[data-te-select-dropdown-ref]")
-//          .should('be.visible')
-//
-//        cy.get("div[role='option']")
-//          .contains(level)
-//          .click()
-//
-//        cy.get("div[role='option']")
-//          .contains(level)
-//          .parent()
-//          .should("have.attr", "data-te-select-selected")
-//      })
-//    }
-//  }
-//})
+describe('Levels Dropdown Select test', () => {
+ const levels = ["3", "5"];
+ for (const level of levels) {
+   for (const teacher of ["teacher1", "teacher4"]) {
+     it(`${teacher} can select level ${level}`, () => {
+       loginForTeacher(teacher);
+       goToEditAdventure();
+
+       // Tests level field interaction
+       cy.get('#custom_adventure_levels_container')
+         .should('be.visible')
+         .should('not.be.disabled')
+         .click()
+
+       cy.wait(400)
+
+       cy.get("div[data-te-select-dropdown-ref]")
+         .should('be.visible')
+
+       cy.get("div[role='option']")
+         .contains(level)
+         .click()
+
+       cy.get("div[role='option']")
+         .contains(level)
+         .parent()
+         .should("have.attr", "data-te-select-selected")
+     })
+   }
+ }
+})

--- a/tests/cypress/e2e/for-teacher_page/customize-adventure_page/level_field.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/customize-adventure_page/level_field.cy.js
@@ -1,34 +1,34 @@
 import {loginForTeacher} from '../../tools/login/login.js'
 import {goToEditAdventure} from '../../tools/navigation/nav.js'
 
-describe('Levels Dropdown Select test', () => {
-  const levels = ["3", "5"];
-  for (const level of levels) {
-    for (const teacher of ["teacher1", "teacher4"]) { 
-      it(`${teacher} can select level ${level}`, () => {
-        loginForTeacher(teacher);
-        goToEditAdventure();
-
-        // Tests level field interaction
-        cy.get('#custom_adventure_levels_container')
-          .should('be.visible')
-          .should('not.be.disabled')
-          .click()
-        
-        cy.wait(400)
-
-        cy.get("div[data-te-select-dropdown-ref]")
-          .should('be.visible')
-        
-        cy.get("div[role='option']")
-          .contains(level)
-          .click()
-        
-        cy.get("div[role='option']")
-          .contains(level)
-          .parent()
-          .should("have.attr", "data-te-select-selected")
-      })
-    }
-  }
-})
+//describe('Levels Dropdown Select test', () => {
+//  const levels = ["3", "5"];
+//  for (const level of levels) {
+//    for (const teacher of ["teacher1", "teacher4"]) {
+//      it(`${teacher} can select level ${level}`, () => {
+//        loginForTeacher(teacher);
+//        goToEditAdventure();
+//
+//        // Tests level field interaction
+//        cy.get('#custom_adventure_levels_container')
+//          .should('be.visible')
+//          .should('not.be.disabled')
+//          .click()
+//
+//        cy.wait(400)
+//
+//        cy.get("div[data-te-select-dropdown-ref]")
+//          .should('be.visible')
+//
+//        cy.get("div[role='option']")
+//          .contains(level)
+//          .click()
+//
+//        cy.get("div[role='option']")
+//          .contains(level)
+//          .parent()
+//          .should("have.attr", "data-te-select-selected")
+//      })
+//    }
+//  }
+//})

--- a/tests/cypress/e2e/for-teacher_page/customize_class_page/customize_class.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/customize_class_page/customize_class.cy.js
@@ -2,9 +2,9 @@ import { loginForTeacher, loginForStudent } from '../../tools/login/login.js'
 import { ensureClass } from "../../tools/classes/class";
 
 describe('customize class page', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       loginForTeacher();
-      await ensureClass();
+      ensureClass();
       cy.getBySel('view_class_link').first().click(); // Press on view class button
       cy.get('body').then($b => $b.find("#survey")).then($s => $s.length && $s.hide())
       cy.getBySel('customize_class_button').click(); // Press customize class button

--- a/tests/cypress/e2e/tools/classes/class.js
+++ b/tests/cypress/e2e/tools/classes/class.js
@@ -30,18 +30,18 @@ export function createClass()
  */
 export function ensureClass()
 {
-    const classname = `test class ${Math.random()}`;
+    let classname = `test class ${Math.random()}`;
     goToTeachersPage();
 
-    return new Promise(ok => {
-        cy.getBySel('view_class_link').then(viewClassLink => {
-            if (viewClassLink.length === 0) {
-                ok(createClass());
-            } else {
-                ok(viewClassLink.text());
-            }
-        });
+    cy.getBySel('view_class_link').then(viewClassLink => {
+        if (viewClassLink.length === 0) {
+            createClass();
+        } else {
+            classname = viewClassLink.text();
+        }
     });
+
+    return classname
 }
 
 export function addStudents(classname, count) {

--- a/tests/cypress/e2e/tools/navigation/nav.js
+++ b/tests/cypress/e2e/tools/navigation/nav.js
@@ -14,62 +14,62 @@ export function goToPage(page)
 
 export function goToHome()
 {
-    return goToPage('/');
+    goToPage('/');
 }
 
 export function goToRegisterStudent()
 {
-    return goToPage(Cypress.env('register_student_page'));
+    goToPage(Cypress.env('register_student_page'));
 }
 
 export function goToRegisterTeacher()
 {
-    return goToPage(Cypress.env('register_teacher_page'));
+    goToPage(Cypress.env('register_teacher_page'));
 }
 
 export function goToLogin()
 {
-    return goToPage(Cypress.env('login_page'));
+    goToPage(Cypress.env('login_page'));
 }
 
 export function goToRecover()
 {
-    return goToPage(Cypress.env('recover_page'));
+    goToPage(Cypress.env('recover_page'));
 }
 
 export function goToTeachersPage()
 {
-    return goToPage(Cypress.env('teachers_page'));
+    goToPage(Cypress.env('teachers_page'));
 }
 
 export function goToHedyPage()
 {
-    return goToPage(Cypress.env('hedy_page'));
+    goToPage(Cypress.env('hedy_page'));
 }
 
 export function goToHedyPageWithEnKeywords()
 {
-    return goToPage(Cypress.env('hedy_english_keywords'));
+    goToPage(Cypress.env('hedy_english_keywords'));
 }
 
 export function goToAdventurePage()
 {
-    return goToPage(Cypress.env('adventure_page'));
+    goToPage(Cypress.env('adventure_page'));
 }
 
 export function goToProfilePage()
 {
-    return goToPage(Cypress.env('profile_page'));
+    goToPage(Cypress.env('profile_page'));
 }
 
 export function goToHedyLevel2Page()
 {
-    return goToPage(Cypress.env('hedy_level2_page'));
+    goToPage(Cypress.env('hedy_level2_page'));
 }
 
 export function goToHedyLevel5Page()
 {
-    return goToPage(Cypress.env('hedy_level5_page'));
+    goToPage(Cypress.env('hedy_level5_page'));
 }
 
 export function goToAdminUsersPage()
@@ -80,17 +80,17 @@ export function goToAdminUsersPage()
 
 export function goToAdminAdventuresPage()
 {
-   return goToPage(Cypress.env('admin_adventures_page'));
+   goToPage(Cypress.env('admin_adventures_page'));
 }
 
 export function goToAdminAchievementsPage()
 {
-   return goToPage(Cypress.env('admin_achievements_page'));
+   goToPage(Cypress.env('admin_achievements_page'));
 }
 
 export function goToAdminClassesPage()
 {
-   return goToPage(Cypress.env('admin_classes_page'));
+   goToPage(Cypress.env('admin_classes_page'));
 }
 
 // Must be logged in and able to edit an adventure
@@ -106,7 +106,7 @@ export function goToEditAdventure()
 
 export function goToExploreProgramsPage()
 {
-   return goToPage(Cypress.env('explore_programs_page'));
+   goToPage(Cypress.env('explore_programs_page'));
 }
 
 export default {goToPage}

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -30,8 +30,8 @@ if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
   app.document.head.appendChild(style);
 }
 
-Cypress.on('uncaught:exception', (err, runnable) => {
-  // returning false here prevents Cypress from
-  // failing the test
-  return false
-})
+//Cypress.on('uncaught:exception', (err, runnable) => {
+//  // returning false here prevents Cypress from
+//  // failing the test
+//  return false
+//})

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 06:39+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ar <LL@li.org>\n"
 "Language: ar\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5);\n"
-"X-Generator: Weblate 5.3-dev\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2328,3 +2328,11 @@ msgstr ""
 
 #~ msgid "tag_deleted"
 #~ msgstr "لقد تم حذف العلامة"
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: bg <LL@li.org>\n"
 "Language: bg\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2612,3 +2612,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: bn <LL@li.org>\n"
 "Language: bn\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2717,3 +2717,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet।"
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher।"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ca <LL@li.org>\n"
 "Language: ca\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2368,3 +2368,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: cs <LL@li.org>\n"
 "Language: cs\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2598,3 +2598,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: cy <LL@li.org>\n"
 "Language: cy\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=5; plural=(n==1 ? 1 : n==2 ? 2 : n==3 ? 3 : n==6 ? 4 : 0);\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2742,3 +2742,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: da <LL@li.org>\n"
 "Language: da\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2732,3 +2732,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: de <LL@li.org>\n"
 "Language: de\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2251,3 +2251,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: el <LL@li.org>\n"
 "Language: el\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2451,3 +2451,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: eo <LL@li.org>\n"
 "Language: eo\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2465,3 +2465,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: es <LL@li.org>\n"
 "Language: es\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2192,3 +2192,11 @@ msgstr "You defined the variable {variable_name} on line {line_number}, but you 
 
 #~ msgid "no_tags"
 #~ msgstr "Aún no hay etiquetas."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: et <LL@li.org>\n"
 "Language: et\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2674,3 +2674,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: fa <LL@li.org>\n"
 "Language: fa\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2718,3 +2718,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: fi <LL@li.org>\n"
 "Language: fi\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2741,3 +2741,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: fr <LL@li.org>\n"
 "Language: fr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2263,3 +2263,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: fy <LL@li.org>\n"
 "Language: fy\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2592,3 +2592,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: he <LL@li.org>\n"
 "Language: he\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2653,3 +2653,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: hi <LL@li.org>\n"
 "Language: hi\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2442,3 +2442,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet।"
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher।"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: hu <LL@li.org>\n"
 "Language: hu\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2597,3 +2597,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: id <LL@li.org>\n"
 "Language: id\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2198,3 +2198,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "Belum ada tag."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: it <LL@li.org>\n"
 "Language: it\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2619,3 +2619,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-11-27 20:54+0100\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ja <LL@li.org>\n"
 "Language: ja\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2700,3 +2700,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: kmr <LL@li.org>\n"
 "Language: kmr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2734,3 +2734,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ko <LL@li.org>\n"
 "Language: ko\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2597,3 +2597,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: none\n"
 "Language: mi\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2601,3 +2601,11 @@ msgstr "Public adventures"
 #, fuzzy
 msgid "no_adventures_yet"
 msgstr "There are no public adventures yet..."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: nb_NO <LL@li.org>\n"
 "Language: nb_NO\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2396,3 +2396,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: nl <LL@li.org>\n"
 "Language: nl\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2210,3 +2210,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: pa_PK <LL@li.org>\n"
 "Language: pa_PK\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2741,3 +2741,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: pap <LL@li.org>\n"
 "Language: pap\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2616,3 +2616,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: pl <LL@li.org>\n"
 "Language: pl\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2245,3 +2245,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
 "Language: pt_BR\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2587,3 +2587,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: pt_PT <LL@li.org>\n"
 "Language: pt_PT\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2614,3 +2614,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ro <LL@li.org>\n"
 "Language: ro\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2727,3 +2727,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ru <LL@li.org>\n"
 "Language: ru\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2274,3 +2274,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: sq <LL@li.org>\n"
 "Language: sq\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2743,3 +2743,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: sr <LL@li.org>\n"
 "Language: sr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2686,3 +2686,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: sv <LL@li.org>\n"
 "Language: sv\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2223,3 +2223,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: sw <LL@li.org>\n"
 "Language: sw\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2627,3 +2627,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: te <LL@li.org>\n"
 "Language: te\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2741,3 +2741,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: th <LL@li.org>\n"
 "Language: th\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2704,3 +2704,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: tl <LL@li.org>\n"
 "Language: tl\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2743,3 +2743,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-15 14:46+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: tn <LL@li.org>\n"
 "Language: tn\n"
@@ -2734,3 +2734,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: tr <LL@li.org>\n"
 "Language: tr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 msgid "Access Before Assign"
@@ -2199,3 +2199,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: uk <LL@li.org>\n"
 "Language: uk\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2521,3 +2521,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: ur <LL@li.org>\n"
 "Language: ur\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2741,3 +2741,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: vi <LL@li.org>\n"
 "Language: vi\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2734,3 +2734,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-15 14:44+0000\n"
-"Last-Translator: Petal <Petalzu@outlook.com>\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
+"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: zh_Hans <LL@li.org>\n"
 "Language: zh_Hans\n"
 "MIME-Version: 1.0\n"
@@ -2227,3 +2227,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-08 17:32-0400\n"
-"PO-Revision-Date: 2023-12-13 14:44+0000\n"
+"PO-Revision-Date: 2023-12-18 20:12+0000\n"
 "Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: zh_Hant <LL@li.org>\n"
 "Language: zh_Hant\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3-rc\n"
+"X-Generator: Weblate 5.3\n"
 "Generated-By: Babel 2.11.0\n"
 
 #, fuzzy
@@ -2732,3 +2732,11 @@ msgstr ""
 
 #~ msgid "no_tags"
 #~ msgstr "No tags yet."
+
+#, fuzzy
+msgid "exit_preview_mode"
+msgstr "Exit preview mode"
+
+#, fuzzy
+msgid "previewing_class"
+msgstr "You are previewing class <em>{class_name}</em> as a teacher."


### PR DESCRIPTION
Oops, the start_code remover removed a block of real content in English, causing weblate to remove that too in #4923 in other languages! We don't want that. This puts the content back, and also grabs the other weblate changes so that we can safely close #4923