### PR TITLE
[BUG] fix cypress memory overusage

### DIFF
--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -5,6 +5,8 @@ module.exports = defineConfig({
   watchForFileChanges: false,
   video: false,
   redirectionLimit: 100,
+  numTestsKeptInMemory: 0,
+  experimentalMemoryManagement: true,
   e2e: {
     baseUrl: 'http://localhost:8080',
     setupNodeEvents(on, config) {


### PR DESCRIPTION
Cypress tests fail due to memory problems. The added flags do two things:
- does not store any test in memory within github actions
- and uses a new memory management recormmended by cypress for Chromium-based browsers.

This will hopefully solve the memory problem we are having lately. 