### PR TITLE
[BUG FIX] Fix embedded editor when in read only mode

### DIFF
--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -11,8 +11,8 @@
     </head>
     <body class="flex flex-col gap-2 h-screen" dir="{{ g.dir }}">
         <div id="editor-area" class="relative grid grid-cols-1 {% if run %}md:grid-cols-2{% endif %} md:grid-flow-row-dense gap-2">
-            <div class="flex flex-col order-1 relative" id="code_editor" style="height: calc(100vh - 4em);">
-                <div id="editor" style="background: #272822; max-height: calc(100vh - 4em); font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
+            <div class="h-full flex flex-col order-1 relative" id="code_editor" {% if run %}style="height: calc(100vh - 4em);"{% endif %}>
+                <div id="editor" style="background: #272822; {% if run %}max-height: calc(100vh - 4em);{% endif %} font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
                 <div id="errorbox"
                   class="flex-0 z-20 mt-0 bg-red-100 border-t-4 border-red-500 rounded-b text-red-900 px-4 py-3 shadow-md" role="alert"
                   style="display: none;">
@@ -60,7 +60,7 @@
                 </div>
             </div>
             {% if run %}
-                <div class="w-full flex flex-col order-2 relative" id="code_output" style="height: calc(100vh - 4em);">
+                <div class="w-full h-full flex flex-col order-2 relative" id="code_output" {% if run %}style="max-height: calc(100vh - 4em);"{% endif %}>
                       <!-- tabindex=0 makes the div focusable -->
                       <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem;"></div>
                       <div id="turtlecanvas" class="flex-0 ltr:pl-4 rtl:pr-4"></div>

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -11,8 +11,8 @@
     </head>
     <body class="flex flex-col gap-2 h-screen" dir="{{ g.dir }}">
         <div id="editor-area" class="relative grid grid-cols-1 {% if run %}md:grid-cols-2{% endif %} md:grid-flow-row-dense gap-2">
-            <div class="h-full flex flex-col order-1 relative" id="code_editor" {% if run %}style="height: calc(100vh - 4em);"{% endif %}>
-                <div id="editor" style="background: #272822; {% if run %}max-height: calc(100vh - 4em);{% endif %} font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
+            <div class="flex flex-col order-1 relative" id="code_editor" {% if run %}style="height: calc(100vh - 4em);"{% else %}style="height: 100vh;{% endif %}">
+                <div id="editor" style="background: #272822; {% if run %}max-height: calc(100vh - 4em);{% else %}max-height: 100vh;{% endif %} font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
                 <div id="errorbox"
                   class="flex-0 z-20 mt-0 bg-red-100 border-t-4 border-red-500 rounded-b text-red-900 px-4 py-3 shadow-md" role="alert"
                   style="display: none;">

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -1,3 +1,8 @@
+{% if run %}
+    {% set editorHeight = 'calc(100vh - 4em)' %}
+{% else %}
+    {% set editorHeight = '100vh' %}
+{% endif %}
 <!doctype html>
 <html lang="{{ language }}" class="notranslate" translate="no">
     <head>
@@ -11,8 +16,8 @@
     </head>
     <body class="flex flex-col gap-2 h-screen" dir="{{ g.dir }}">
         <div id="editor-area" class="relative grid grid-cols-1 {% if run %}md:grid-cols-2{% endif %} md:grid-flow-row-dense gap-2">
-            <div class="flex flex-col order-1 relative" id="code_editor" {% if run %}style="height: calc(100vh - 4em);"{% else %}style="height: 100vh;{% endif %}">
-                <div id="editor" style="background: #272822; {% if run %}max-height: calc(100vh - 4em);{% else %}max-height: 100vh;{% endif %} font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
+            <div class="flex flex-col order-1 relative" id="code_editor" style="height: {{ editorHeight }};">
+                <div id="editor" style="background: #272822; max-height: {{ editorHeight }}; font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
                 <div id="errorbox"
                   class="flex-0 z-20 mt-0 bg-red-100 border-t-4 border-red-500 rounded-b text-red-900 px-4 py-3 shadow-md" role="alert"
                   style="display: none;">

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -60,7 +60,7 @@
                 </div>
             </div>
             {% if run %}
-                <div class="w-full flex flex-col order-2 relative" id="code_output" style="max-height: calc(100vh - 4em);">
+                <div class="w-full flex flex-col order-2 relative" id="code_output" style="height: calc(100vh - 4em);">
                       <!-- tabindex=0 makes the div focusable -->
                       <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem;"></div>
                       <div id="turtlecanvas" class="flex-0 ltr:pl-4 rtl:pr-4"></div>

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -60,7 +60,7 @@
                 </div>
             </div>
             {% if run %}
-                <div class="w-full h-full flex flex-col order-2 relative" id="code_output" {% if run %}style="max-height: calc(100vh - 4em);"{% endif %}>
+                <div class="w-full flex flex-col order-2 relative" id="code_output" style="max-height: calc(100vh - 4em);">
                       <!-- tabindex=0 makes the div focusable -->
                       <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem;"></div>
                       <div id="turtlecanvas" class="flex-0 ltr:pl-4 rtl:pr-4"></div>


### PR DESCRIPTION
This PR fixes a bug where there would be whitespace add the bottom of the embedded editor when on readonly and disabled run mode. This because we calculated the height of the editor based on the height of the run button. But if it's not there, no need to take this space!

The following test link should no longer have whitespace at the bottom:
http://127.0.0.1:8080/embedded/1/?lang=nl&run=false&readOnly=true&program=cHJpbnQgZGl0IGlzIGVlbiB0ZXN0IQplY2hvIHdhYXJvbSBrbG9wdCBkaXQgbmlldD8KdGVzdCB0ZXN0CnRlc3QgdGVzdA%3D%3D