### PR TITLE
Add support for full width embedded editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -1647,6 +1647,7 @@ def get_embedded_code_editor(level):
         level = 1
 
     run = True if request.args.get('run') == 'true' else False
+    fullWidth = True if request.args.get('fullWidth') == 'true' else False
     readOnly = True if request.args.get('readOnly') == 'true' else False
     encoded_program = request.args.get('program')
 
@@ -1671,7 +1672,7 @@ def get_embedded_code_editor(level):
         except binascii.Error:
             program = gettext('invalid_program_comment')
 
-    return render_template("embedded-editor.html", embedded=True, run=run, language=language,
+    return render_template("embedded-editor.html", fullWidth=fullWidth, run=run, language=language,
                            keyword_language=keyword_language, readOnly=readOnly,
                            level=level, javascript_page_options=dict(
                                page='view-program',

--- a/templates/embedded-editor.html
+++ b/templates/embedded-editor.html
@@ -1,5 +1,9 @@
 {% if run %}
-    {% set editorHeight = 'calc(100vh - 4em)' %}
+    {% if fullWidth %}
+        {% set editorHeight = 'calc(50vh - 2em)' %}
+    {% else %}
+        {% set editorHeight = 'calc(100vh - 4em)' %}
+    {% endif %}
 {% else %}
     {% set editorHeight = '100vh' %}
 {% endif %}
@@ -15,7 +19,7 @@
         <link rel="stylesheet" href="{{static('/fontawesome/css/all.min.css')}}"/>
     </head>
     <body class="flex flex-col gap-2 h-screen" dir="{{ g.dir }}">
-        <div id="editor-area" class="relative grid grid-cols-1 {% if run %}md:grid-cols-2{% endif %} md:grid-flow-row-dense gap-2">
+        <div id="editor-area" class="relative grid grid-cols-1 {% if run and not fullWidth %}md:grid-cols-2{% endif %} md:grid-flow-row-dense gap-2">
             <div class="flex flex-col order-1 relative" id="code_editor" style="height: {{ editorHeight }};">
                 <div id="editor" style="background: #272822; max-height: {{ editorHeight }}; font-size:0.95em; color: white" blurred="false" class="h-full w-full flex-1 text-lg rounded min-h-0 overflow-hidden fixed-editor-height" {% if readOnly %}data-readonly="true"{% endif %}></div>
                 <div id="errorbox"
@@ -65,7 +69,7 @@
                 </div>
             </div>
             {% if run %}
-                <div class="w-full flex flex-col order-2 relative" id="code_output" style="height: calc(100vh - 4em);">
+                <div class="w-full flex flex-col order-2 relative" id="code_output" style="height: {{ editorHeight }}">
                       <!-- tabindex=0 makes the div focusable -->
                       <div id="output" tabindex=0 class="flex-1 rounded p-2 px-3 bg-gray-900 color-white w-full text-lg overflow-auto" style="min-height: 3rem;"></div>
                       <div id="turtlecanvas" class="flex-0 ltr:pl-4 rtl:pr-4"></div>


### PR DESCRIPTION
In this PR we add the option to display the embedded editor in column mode instead of row mode. Instead of the editor and output being responsive we add a parameter to allowed customization. This is especially handy when being embedded on a small width screen but with sufficient height and a longer program.

To test try the following longer program:
http://127.0.0.1:8080/embedded/17/?lang=nl&run=true&readOnly=false&fullWidth=true&program=ZGVmaW5lIGZvb2Rfb3JkZXIKICAgIHRvcHBpbmdzID0gYXNrICdwZXBwZXJvbmksIHR1bmEsIHZlZ2dpZSBvciBjaGVlc2U%2FJwogICAgc2l6ZSA9IGFzayAnYmlnLCBtZWRpdW0gb3Igc21hbGw%2FJwogICAgbnVtYmVyX29mX3BpenphID0gYXNrICdIb3cgbWFueSB0aGVzZSBwaXp6YXMgd291bGQgeW91IGxpa2U%2FJwoKICAgIHByaW50ICdZT1UgT1JERVJFRCcKICAgIHByaW50IG51bWJlcl9vZl9waXp6YXMgJyBzaXplICAnIHRvcHBpbmcgJyBwaXp6YScKCmRlZmluZSBkcmlua3Nfb3JkZXIKICAgIGRyaW5rID0gYXNrICd3YXRlciwgY29rZSwgaWNldGVhLCBsZW1vbmFkZSBvciBjb2ZmZWU%2FJwogICAgbnVtYmVyX29mX2RyaW5rcyA9IGFzayAnSG93IG1hbnkgb2YgdGhlc2UgZHJpbmtzIHdvdWxkIHlvdSBsaWtlPycKCiAgICBwcmludCAnWU9VIE9SREVSRUQnCiAgICBwcmludCBudW1iZXJfb2ZfZHJpbmtzICcgJyBkcmluawoKJ1dlbGNvbWUgdG8gSGVkeSBwaXp6YScKbW9yZV9mb29kID0gYXNrICdXb3VsZCB5b3UgbGlrZSB0byBvcmRlciBhIHBpenphPycKd2hpbGUgbW9yZV9mb29kID0gJ3llcycKICAgIHJldHVybiBmb29kX29yZGVyCiAgICBtb3JlX2Zvb2QgPSBhc2sgJ1dvdWxkIHlvdSBsaWtlIHRvIG9yZGVyIGEgcGl6emE%2FJwptb3JlX2RyaW5rcyA9IGFzayAnV291bGQgeW91IGxpa2UgdG8gb3JkZXIgc29tZSBkcmlua3M%2FJwp3aGlsZSBtb3JlX2RyaW5rcyA9PSAneWVzJwogICAgY2FsbCBkcmlua19vcmRlcgogICAgbW9yZV9kcmlua3MgPT0gYXNrICdXb3VsZCB5b3UgbGlrZSB0byBvcmRlciBtb3JlIGRyaW5rcz8nCgoKcHJpbnQgJ1RoYW5rcyBmb3Igb3JkZXJpbmchJw%3D%3D