### PR TITLE
🚚 add `doit run devserver` command

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -275,6 +275,7 @@ def task_extract():
         ],
     )
 
+
 def task_devserver():
     """Run a copy of the development server.
 

--- a/dodo.py
+++ b/dodo.py
@@ -25,6 +25,8 @@ from os import path
 from glob import glob
 import sys
 
+from doit.tools import LongRunning
+
 
 # The current Python interpreter, use to run other Python scripts as well
 python3 = sys.executable
@@ -271,6 +273,30 @@ def task_extract():
             'pybabel extract -F babel.cfg -o messages.pot . --no-location --sort-output',
             'pybabel update -i messages.pot -d translations -N --no-wrap',
         ],
+    )
+
+def task_devserver():
+    """Run a copy of the development server.
+
+    This server is configured to be useful for running cypress tests against.
+
+    No file dependencies, so this task is never skipped.
+
+    Be careful to only depend on `backend` tasks, not `frontend` tasks, so that
+    the people running this command still don't need to have Node installed
+    if they don't want to work on the frontend.
+    """
+    return dict(
+        title=lambda _: 'Run development server',
+        task_dep=['backend'],
+        actions=[
+            LongRunning([python3, 'app.py'], shell=False, env=dict(
+                os.environ,
+                # These are required to make some local features work.
+                BASE_URL="http://localhost:8080/",
+                ADMIN_USER="admin"))
+        ],
+        verbosity=2,  # show everything live
     )
 
 


### PR DESCRIPTION
While updating the [Hedy development wiki](https://github.com/hedyorg/hedy/wiki/Hedy-Development-Process) to match the newest ways to run scripts using `doit`, I noticed that there are still some elaborate instructions around running scripts and setting environment variables etc in there.

Those can be encoded using `doit` as well, so that running a local copy of the server can be as simple as:

```
doit run devserver
```

This will take care of recompiling Babel files when necessary, so that those instructions can be removed. It sets the environment variables that some parts of the code require (`BASE_URL` and `ADMIN_USER`) so that those instructions can be removed as well.

**How to test**

Run:

```
doit run devdb frontend devserver
```

Observe that Babel files are regenerated, before the dev server is eventually run. Run `npm run cypress` in a different terminal and observe that all tests succeed.

(`devserver` purposely does not depend on `frontend`, so that people can run a copy of the `devserver` without having Node installed)