### PR TITLE
🚚 Detect Heroku without setting additional environment variables

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -386,7 +386,11 @@ def babel_version_unchanged(task, values):
 
 
 def is_running_on_heroku():
-    return 'ON_HEROKU' in os.environ
+    """Return True if we are running on Heroku.
+
+    Check an environment variable that Heroku sets by default.
+    """
+    return 'DYNO' in os.environ
 
 
 # These are used in more than one task. Find all .po files, and calculate the


### PR DESCRIPTION
`ON_HEROKU` was a variable we needed to set ourselves, but `DYNO` is automatically set by Heroku.

That means we can't forget to configure it on new environments

**How to test**

Deploy to alpha and prod. It succeeds.