### PR TITLE
💻 If no classes or adventures, show info

### DIFF
--- a/templates/for-teachers.html
+++ b/templates/for-teachers.html
@@ -21,7 +21,7 @@
             </svg>
           </button>
         </div>
-        <div class="border border-gray-400 px-4 rounded-lg w-full lg:w-3/4 p-4 text-center hidden" id="classes_info">
+        <div class="border border-gray-400 px-4 rounded-lg w-full lg:w-3/4 p-4 text-center {% if teacher_classes %}hidden{% endif %}" id="classes_info">
           <p>
             {{ _('classes_info') }}
           </p>
@@ -66,7 +66,7 @@
           </svg>
         </button>
       </div>
-      <div class="border border-gray-400 px-4 rounded-lg w-full lg:w-3/4 p-4 text-center hidden" id="adventures_info">
+      <div class="border border-gray-400 px-4 rounded-lg w-full lg:w-3/4 p-4 text-center {% if teacher_adventures %}hidden{% endif %}" id="adventures_info">
         <p>
           {{ _('adventures_info') }}
         </p>


### PR DESCRIPTION
Fixes #4645 

**How to test**
Go to the `/for-teachers` page and remove all classes and adventures. The class info or adventure info is now visible. If you add a class or adventure, the info is not visible. 

<img width="1440" alt="Screenshot 2024-01-18 at 12 07 30" src="https://github.com/hedyorg/hedy/assets/48122190/39a2f4e9-efc1-4ad8-9614-7b15807da6f9">
<img width="1440" alt="Screenshot 2024-01-18 at 12 07 40" src="https://github.com/hedyorg/hedy/assets/48122190/b02c0254-4266-4a60-b152-1900c1066eb6">
