### PR TITLE
📜 Update public adventures string

### DIFF
--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1419,7 +1419,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "اختيار الاتفاقية هذا غير صالح"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -1613,7 +1613,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -1679,7 +1679,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -1456,7 +1456,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -1606,7 +1606,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -1691,7 +1691,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -1692,7 +1692,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1320,7 +1320,7 @@ msgid "public"
 msgstr "Öffentlich"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Diese Einverständnisauswahl ist ungültig"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -1462,7 +1462,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Αυτή η επιλογή συμφωνίας δεν είναι έγκυρη"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1284,7 +1284,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -1496,7 +1496,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1284,7 +1284,7 @@ msgid "public"
 msgstr "Público"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "La selección de conformidad no es correcta"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -1650,7 +1650,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -1668,7 +1668,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -1690,7 +1690,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -1336,7 +1336,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Cette sélection d'accord est invalide"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -1593,7 +1593,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -1634,7 +1634,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -1487,7 +1487,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "यह अनुबंध चयन अमान्य है"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -1593,7 +1593,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1320,7 +1320,7 @@ msgid "public"
 msgstr "Publik"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Pilihan perjanjian ini tidak valid"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1607,7 +1607,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -1668,7 +1668,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -1692,7 +1692,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -1693,7 +1693,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -1693,7 +1693,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1447,7 +1447,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Dette avtale valget er ugyldig"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -1309,7 +1309,7 @@ msgid "public"
 msgstr "Openbaar"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Bekijk alle publieke avonturen"
 
 msgid "public_invalid"
 msgstr "Deze waarde voor het beschikbaar maken van je avontuur is ongeldig"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -1688,7 +1688,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -1693,7 +1693,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -1336,7 +1336,7 @@ msgid "public"
 msgstr "Publiczne"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Niepoprawna wartość zgody"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1589,7 +1589,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1613,7 +1613,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -1687,7 +1687,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -1347,7 +1347,7 @@ msgid "public"
 msgstr "Общественный"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Выбор данного соглашения является недействительным"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -1690,7 +1690,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -1659,7 +1659,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -1328,7 +1328,7 @@ msgid "public"
 msgstr "Offentlig"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Avtalsvalet är ogiltigt"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -1622,7 +1622,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -1690,7 +1690,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -1654,7 +1654,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -1691,7 +1691,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -1685,7 +1685,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1311,7 +1311,7 @@ msgid "public"
 msgstr "Herkese açık"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 msgid "public_invalid"
 msgstr "Bu anlaşma seçimi geçersizdir"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -1498,7 +1498,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -1688,7 +1688,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -1687,7 +1687,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1354,7 +1354,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -1690,7 +1690,7 @@ msgid "public"
 msgstr "Public"
 
 msgid "public_adventures"
-msgstr ""
+msgstr "Browse public adventures"
 
 #, fuzzy
 msgid "public_invalid"


### PR DESCRIPTION
Hi @hasan-sh!

I just noticed this string is still missing: 

<img width="433" alt="image" src="https://github.com/hedyorg/hedy/assets/1003685/971abb2d-07cb-4233-971c-1f7f24abf9b0">

But rather than making an issue I though I can just fix it right away :) 

I think you may have added it at one point, but @akseron's changes set it ba k to empty. Can you approve if this looks ok?