### PR TITLE
🪲 Render command in quiz title

### DIFF
--- a/templates/quiz/partial-question.html
+++ b/templates/quiz/partial-question.html
@@ -7,7 +7,7 @@
     {% include "quiz/incl-question-progress.html" %}
     <div>
         <div class="my-10 text-3xl font-bold text-blue-900 text-center">
-            {{ question.text }}
+            {{ question.text|commonmark }}
         </div>
         {% if question.code %}
         <div class="turn-pre-into-ace w-2/3 max-w-3xl mx-auto my-4 ace-container">


### PR DESCRIPTION
Fixes #4743 

**How to test**
Go to, for example, level 3 - question 7. The command 'add' is now rendered as an command.

<img width="1423" alt="Screenshot 2024-01-23 at 14 25 45" src="https://github.com/hedyorg/hedy/assets/48122190/8b448582-37c0-42c8-bb97-771fa49c2cd8">
