### PR TITLE
🪲 fix keywords not changing to en

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -1681,8 +1681,9 @@ export async function change_language(lang: string) {
       if (urlParams.get('keyword_language') !== null) {
         urlParams.set('keyword_language', 'en');
       }
-      if (urlParams.get("language") !== null) {
+      if (lang === 'en' || urlParams.get("language") !== null) {
         urlParams.set("language", lang)
+        urlParams.set('keyword_language', lang);
         window.location.search = urlParams.toString();
       } else {
         location.reload();

--- a/static/js/appbundle.js
+++ b/static/js/appbundle.js
@@ -58035,8 +58035,9 @@ pygame.quit()
         if (urlParams.get("keyword_language") !== null) {
           urlParams.set("keyword_language", "en");
         }
-        if (urlParams.get("language") !== null) {
+        if (lang === "en" || urlParams.get("language") !== null) {
           urlParams.set("language", lang);
+          urlParams.set("keyword_language", lang);
           window.location.search = urlParams.toString();
         } else {
           location.reload();


### PR DESCRIPTION
Fixes #5063 

**How to test?**
- change language to any
- then change the keyword to en and back to your chosen language
- now chage language to en or any other,
- the keyword should also change accordingly.