### PR TITLE
🖊️ Add support for floats in lists in level 16 and up

### DIFF
--- a/grammars/level16-Additions.lark
+++ b/grammars/level16-Additions.lark
@@ -7,7 +7,7 @@ command:+= change_list_item
 ?atom: NUMBER | _MINUS NUMBER | var_access | list_access | text_in_quotes
 list_access: var_access _LEFT_SQUARE_BRACKET (INT | random | var_access) _RIGHT_SQUARE_BRACKET
 change_list_item: var_access _LEFT_SQUARE_BRACKET (INT | var_access) _RIGHT_SQUARE_BRACKET _EQUALS (var_access | textwithoutspaces)
-assign_list: var (_IS | _EQUALS) _LEFT_SQUARE_BRACKET ((quoted_text | INT) (_COMMA (quoted_text | INT))*)? _RIGHT_SQUARE_BRACKET
+assign_list: var (_IS | _EQUALS) _LEFT_SQUARE_BRACKET ((quoted_text | NUMBER) (_COMMA (quoted_text | NUMBER))*)? _RIGHT_SQUARE_BRACKET
 
 error_list_access_at: var_access _AT (INT | random)
 

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -36,20 +36,51 @@ class TestsLevel16(HedyTester):
 
         self.multi_level_tester(
             code=code,
-            max_level=17,
             unused_allowed=True,
             expected=expected
         )
 
-    def test_create_with_single_item(self):
-        code = "friends = ['Ashli']"
-        expected = "friends = ['Ashli']"
+    @parameterized.expand([
+        ("'Ashli'", 'Ashli'),
+        ("'\"Ashli\"'", '"Ashli"'),
+        ('"Ashli"', 'Ashli'),
+        ('"Ashli\'s"', 'Ashli\'s'),
+        ('42', 42),
+        ('-1', -1),
+        ('1.5', 1.5),
+        ('-0.7', -0.7)
+    ])
+    def test_create_list_single_item(self, item_code, expected_value):
+        code = f"friends = [{item_code}]"
+        expected = f"friends = [{item_code}]"
 
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Ashli')
+        check_in_list = (lambda x: HedyTester.run_code(x) == expected_value)
 
         self.multi_level_tester(
             code=code,
-            max_level=17,
+            expected=expected,
+            unused_allowed=True,
+            extra_check_function=check_in_list
+        )
+
+    @parameterized.expand([
+        ("'Alice', 'Ben'", ['Alice', 'Ben']),
+        ("'\"a\"', '\"Ben\"'", ['"Alice"', '"Ben"']),
+        ('"Alice", "Ben"', ['Alice', 'Ben']),
+        ('"Alice\'s", "Ben\'s"', ["Alice's", "Ben's"]),
+        ('1, 3, 5', [1, 3, 5]),
+        ('-1, -2, -5', [-1, -2, -5]),
+        ('1.5, 2.6, 3.7', [1.5, 2.6, 3.7]),
+        ('-0.1, -5.6', [-0.1, -5.6])
+    ])
+    def test_create_list_multi_items(self, items_code, expected_items):
+        code = f"friends = [{items_code}]"
+        expected = f"friends = [{items_code}]"
+
+        check_in_list = (lambda x: HedyTester.run_code(x) in expected_items)
+
+        self.multi_level_tester(
+            code=code,
             expected=expected,
             unused_allowed=True,
             extra_check_function=check_in_list


### PR DESCRIPTION
- Fixes #3673 
- With this change, starting from level 16, lists can be created with floating point literals, e.g. `a = [0.1, 0.2]`

**How to test**

* The introduced change is covered by automated unit tests. Ensure that they fully cover the grammar change.
* Start Hedy locally and open level 16. Run the following code `a = [1.5, 2.5, 3.5]` and ensure that there is no "We can't run your program" error.