### PR TITLE
🪲 Fix type error when concatinating ask input and a literal string

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -832,7 +832,7 @@ class TypeValidator(Transformer):
         return self.to_sum_typed_tree(tree, Command.division)
 
     def to_sum_typed_tree(self, tree, command):
-        rules = [int_to_float, input_to_int, input_to_float]
+        rules = [int_to_float, input_to_int, input_to_float, input_to_string]
         prom_left_type, prom_right_type = self.validate_binary_command_args_type(command, tree, rules)
         return TypedTree(tree.data, tree.children, tree.meta, prom_left_type)
 

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -274,7 +274,7 @@ class HedyTester(unittest.TestCase):
                         self.assertEqual(expected_commands, all_commands)
                     # <- use this to run tests locally with unittest
                     skipped_commands = ['ask', 'input', 'clear', 'play']
-                    if not any(x for x in all_commands):
+                    if not any(x for x in skipped_commands if x in all_commands):
                         self.assertTrue(self.validate_Python_code(result))
                     if output is not None:
                         if extra_check_function is None:  # most programs have no turtle so make that the default

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -1923,6 +1923,72 @@ class TestsLevel12(HedyTester):
             extra_check_function=lambda c: c.exception.arguments['line_number'] == 1,
             exception=hedy.exceptions.InvalidArgumentTypeException)
 
+    def test_concat_promotes_ask_input_to_string(self):
+        code = textwrap.dedent("""\
+            answer is ask 'Yes or No?'
+            print 'The answer is ' + answer""")
+
+        expected = textwrap.dedent("""\
+            answer = input(f'''Yes or No?''')
+            try:
+              answer = int(answer)
+            except ValueError:
+              try:
+                answer = float(answer)
+              except ValueError:
+                pass
+            print(f'''{'The answer is ' + answer}''')""")
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected
+        )
+
+    def test_concat_promotes_ask_input_to_int(self):
+        code = textwrap.dedent("""\
+            answer is ask '1 or 2?'
+            print 5 + answer""")
+
+        expected = textwrap.dedent("""\
+            answer = input(f'''1 or 2?''')
+            try:
+              answer = int(answer)
+            except ValueError:
+              try:
+                answer = float(answer)
+              except ValueError:
+                pass
+            print(f'''{5 + answer}''')""")
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected
+        )
+
+    def test_concat_promotes_ask_input_to_float(self):
+        code = textwrap.dedent("""\
+            answer is ask '1 or 2?'
+            print 0.5 + answer""")
+
+        expected = textwrap.dedent("""\
+            answer = input(f'''1 or 2?''')
+            try:
+              answer = int(answer)
+            except ValueError:
+              try:
+                answer = float(answer)
+              except ValueError:
+                pass
+            print(f'''{0.5 + answer}''')""")
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected
+        )
+
     # def test_access_variable_before_definition(self):
     #   code = textwrap.dedent("""\
     #           a is b


### PR DESCRIPTION
- Fixes #2689
- Addresses a hedy type error when an input from an ask statement with concatenated with a literal string

**How to test**
- There are unit tests for the change. Please check whether they correctly cover the change.
- Run hedy locally and go to level 12. Check that the following code does not produce a type error. Instead, the program should execute and prompt the user for input.
```
answer is ask 'Yes or No?'
print 'The answer is ' + answer
```
- Pay special attention to the tiny change in the tests/Tester.py because it affects the whole test suite. I am confident the change is needed based on the history of the file.
