### PR TITLE
🪲 Debug play

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -1013,6 +1013,15 @@ export function runPythonProgram(this: any, code: string, sourceMap: any, hasTur
   code = code_prefix + code;
   if (hasPygame) code += pygame_suffix;
 
+  (Sk as any).builtins.play = new Sk.builtin.func((notes:any) => {
+    //const now = Tone.now()
+    const note_name = notes.v;
+    console.log(notes)
+    //play note_name for the duration of an 16th note
+    synth.triggerAttackRelease(note_name, "16n");
+
+  });
+
   if (run_type === "run") {
     Sk.configure({
       output: outf,
@@ -1049,15 +1058,6 @@ export function runPythonProgram(this: any, code: string, sourceMap: any, hasTur
         // Set a time-out of either 20 seconds when having a sleep and 5 seconds when not
         return ((hasSleep) ? 20000 : 5000);
       }) ()
-    });
-
-    (Sk as any).builtins.play = new Sk.builtin.func((notes:any) => {
-        //const now = Tone.now()
-        const note_name = notes.v;
-
-        //play note_name for the duration of an 16th note
-        synth.triggerAttackRelease(note_name, "16n");
-
     });
 
     return Sk.misceval.asyncToPromise(() =>

--- a/static/js/debugging.ts
+++ b/static/js/debugging.ts
@@ -20,6 +20,7 @@ const fullLineCommands = [
   'add',
   'remove',
   'ask',
+  'play',
   'command', // the turtle and clear commands get put in the source map as 'command'
 ]
 


### PR DESCRIPTION
Adds the built-in function for the play command before choosing to run or debug the program, this way the function is also available for the debugger. 

With this change we got it working in level 1, but not in level 2 onwards.


Fixes #5111
