### PR TITLE
🪲 Fix incorrect transpiling with in/not-in checks for lists with numbers

### DIFF
--- a/content/adventures/sq.yaml
+++ b/content/adventures/sq.yaml
@@ -4019,7 +4019,7 @@ adventures:
                     {for} i {in} {range} 1 {to} 9
                         {if} loja != 'mbaruar'
                             zgjedhje = {ask} 'Lojtari ' shenja ', cili vend?'
-                            {if} zgjedhjе {in} pika_të_hapura
+                            {if} zgjedhje {in} pika_të_hapura
                                 {remove} zgjedhje {from} pika_të_hapura
                                 {if} zgjedhje == 1
                                     vendi_1 = shenja

--- a/hedy.py
+++ b/hedy.py
@@ -1411,6 +1411,13 @@ class ConvertToPython(Transformer):
             arg = arg[1:-1]
         return f"'{process_characters_needing_escape(arg)}'"
 
+    def process_variable_without_quotes(self, arg, access_line_number=100):
+        if self.is_variable(arg, access_line_number):
+            # add this access line to the lookup table
+            self.add_variable_access_location(arg, access_line_number)
+            return escape_var(arg)
+        return arg
+
     def process_variable_for_fstring(self, variable_name, access_line_number=100):
         self.add_variable_access_location(variable_name, access_line_number)
 
@@ -1443,8 +1450,9 @@ class ConvertToPython(Transformer):
         return name
 
     def check_var_usage(self, args, var_access_linenumber=100):
-        # this function checks whether arguments are valid
-        # we can proceed if all arguments are either quoted OR all variables
+        # This function should be used up until level 11 where quotes around strings are NOT required
+        # It succeeds if all args are valid. An arg is valid if it is either quoted or a variable
+        # If an unquoted arg is not present in the lookup table, an UndefinedVarException is raised
 
         def is_var_candidate(arg) -> bool:
             return not isinstance(arg, Tree) and \
@@ -1470,6 +1478,19 @@ class ConvertToPython(Transformer):
                 if current_arg is None:
                     first_unquoted_var = a
                     raise exceptions.UndefinedVarException(name=first_unquoted_var, line_number=var_access_linenumber)
+
+    def check_var_usage_when_quotes_are_required(self, arg, meta):
+        # This method should be used from level 12 and up where quotes around strings are required
+        # The arg is valid if it is either an int, a float, the 'random' operator, a quoted string,
+        # or a variable. If the arg is an unquoted string which is not in the lookup table, an
+        # UnquotedAssignTextException is raised. Most likely the real is that the kid forgot to add quotes.
+        try:
+            self.check_var_usage([arg], meta.line)
+        except exceptions.UndefinedVarException:
+            if not (ConvertToPython.is_int(arg) or
+                    ConvertToPython.is_float(arg) or
+                    ConvertToPython.is_random(arg)):
+                raise exceptions.UnquotedAssignTextException(text=arg, line_number=meta.line)
 
     # static methods
 
@@ -2454,24 +2475,25 @@ class ConvertToPython_12(ConvertToPython_11):
         values = args[1:]
         return parameter + " = [" + ", ".join(values) + "]" + self.add_debug_breakpoint()
 
+    def in_list_check(self, meta, args):
+        left_hand_side = args[0]
+        right_hand_side = args[1]
+        self.check_var_usage_when_quotes_are_required(left_hand_side, meta)
+        self.check_var_usage_when_quotes_are_required(right_hand_side, meta)
+        return f"{left_hand_side} in {right_hand_side}"
+
+    def not_in_list_check(self, meta, args):
+        left_hand_side = args[0]
+        right_hand_side = args[1]
+        self.check_var_usage_when_quotes_are_required(left_hand_side, meta)
+        self.check_var_usage_when_quotes_are_required(right_hand_side, meta)
+        return f"{left_hand_side} not in {right_hand_side}"
+
     def assign(self, meta, args):
         right_hand_side = args[1]
         left_hand_side = args[0]
 
-        # we now need to check if the right hand side of te assign is
-        # either a var or quoted, if it is not (and undefined var is raised)
-        # the real issue is probably that the kid forgot quotes
-        try:
-            # check_var_usage expects a list of arguments so place this one in a list.
-            self.check_var_usage([right_hand_side], meta.line)
-        except exceptions.UndefinedVarException:
-            # is the text a number? then no quotes are fine. if not, raise maar!
-
-            if not (ConvertToPython.is_int(right_hand_side) or ConvertToPython.is_float(
-                    right_hand_side) or ConvertToPython.is_random(right_hand_side)):
-                raise exceptions.UnquotedAssignTextException(
-                    text=args[1],
-                    line_number=meta.line)
+        self.check_var_usage_when_quotes_are_required(right_hand_side, meta)
 
         if isinstance(right_hand_side, Tree):
             exception = self.make_catch_exception([right_hand_side.children[0]])

--- a/highlighting/lezer-grammars/level10.grammar
+++ b/highlighting/lezer-grammars/level10.grammar
@@ -45,9 +45,9 @@ If { ifs+ Condition }
 Else { elses+ }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int) is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 Repeat { repeat+ (Int | Text) times+ }

--- a/highlighting/lezer-grammars/level11.grammar
+++ b/highlighting/lezer-grammars/level11.grammar
@@ -45,9 +45,9 @@ If { ifs+ Condition }
 Else { elses+ }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int) is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 Repeat { repeat+ (Int | Text) times+ }

--- a/highlighting/lezer-grammars/level12.grammar
+++ b/highlighting/lezer-grammars/level12.grammar
@@ -47,9 +47,9 @@ If { ifs+ Condition }
 Else { elses+ } 
 
 Condition { 
-    EqualityCheck { Text (is+ | Op<"=">) (Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (String | Text | Number) (is+ | Op<"=">) (Expression | pressed+) } |
+    InListCheck { (String | Text | Number) ins+ Text } |
+    NotInListCheck { (String | Text | Number) not_in+ Text }
 }
 
 Repeat { repeat+ (Number | Text) times+ }

--- a/highlighting/lezer-grammars/level13.grammar
+++ b/highlighting/lezer-grammars/level13.grammar
@@ -47,9 +47,9 @@ If { ifs+ Condition ((and+ | or+) Condition)* }
 Else { elses+ } 
 
 Condition { 
-    EqualityCheck { Text (is+ | Op<"=">) (Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (String | Text | Number) (is+ | Op<"=">) (Expression | pressed+) } |
+    InListCheck { (String | Text | Number) ins+ Text } |
+    NotInListCheck { (String | Text | Number) not_in+ Text }
 }
 
 Repeat { repeat+ (Number | Text) times+ }

--- a/highlighting/lezer-grammars/level6.grammar
+++ b/highlighting/lezer-grammars/level6.grammar
@@ -49,9 +49,9 @@ If { ifs+ Condition eol* IfLessCommand Else? }
 Else { !else elses+ eol* IfLessCommand }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int)  is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 ErrorInvalid[@dynamicPrecedence=-10] { Text+ }

--- a/highlighting/lezer-grammars/level7.grammar
+++ b/highlighting/lezer-grammars/level7.grammar
@@ -49,9 +49,9 @@ If { ifs+ Condition eol* IfLessCommand Else? }
 Else { !else elses+ eol* IfLessCommand }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int) is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 Repeat { repeat+ (Int | Text) times+ Command? }

--- a/highlighting/lezer-grammars/level8.grammar
+++ b/highlighting/lezer-grammars/level8.grammar
@@ -45,9 +45,9 @@ If { ifs+ Condition }
 Else { elses+ }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int) is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 Repeat { repeat+ (Int | Text) times+ }

--- a/highlighting/lezer-grammars/level9.grammar
+++ b/highlighting/lezer-grammars/level9.grammar
@@ -46,9 +46,9 @@ If { ifs+ Condition }
 Else { elses+ }
 
 Condition { 
-    EqualityCheck { Text is+ (String | Expression | pressed+) } |
-    InListCheck { Text ins+  Text } |
-    NotInListCheck { Text not_in+  Text }
+    EqualityCheck { (Text | Int) is+ (String | Expression | pressed+) } |
+    InListCheck { (Text | Int) ins+ Text } |
+    NotInListCheck { (Text | Int) not_in+ Text }
 }
 
 Repeat { repeat+ (Int | Text) times+ }

--- a/tests/cypress/e2e/lezer-tests/level_05.cy.js
+++ b/tests/cypress/e2e/lezer-tests/level_05.cy.js
@@ -146,6 +146,38 @@ describe('Lezer parser tests for level 5', () => {
 
                 singleLevelTester('Test print command after if', code, expectedTree, 5);
             })
+
+            describe('Test if text in list print', () => {
+                const code = `if text in list print 'in'`
+                const expectedTree =
+                `Program(
+                    Command(
+                        If(
+                            if,
+                            Condition(InListCheck(Text,in,Text)),
+                            IfLessCommand(Print(print,String))
+                        )
+                    )
+                )`
+
+                multiLevelTester('Test if text in list print', code, expectedTree, 5, 7);
+            })
+
+            describe('Test if text not in list print', () => {
+                const code = `if text not in list print 'in'`
+                const expectedTree =
+                `Program(
+                    Command(
+                        If(
+                            if,
+                            Condition(NotInListCheck(Text,not_in,not_in,Text)),
+                            IfLessCommand(Print(print,String))
+                        )
+                    )
+                )`
+
+                multiLevelTester('Test if text not in list print', code, expectedTree, 5, 7);
+            })
         });
     });
 })

--- a/tests/cypress/e2e/lezer-tests/level_06.cy.js
+++ b/tests/cypress/e2e/lezer-tests/level_06.cy.js
@@ -207,5 +207,37 @@ describe('Lezer parser tets for level 6', () => {
 
             multiLevelTester('Test assignment with expression', code, expectedTree, 6, 11);
         })
+
+        describe('Test if number in list print', () => {
+            const code = `if 5 in list print 'in'`
+            const expectedTree =
+            `Program(
+                Command(
+                    If(
+                        if,
+                        Condition(InListCheck(Int,in,Text)),
+                        IfLessCommand(Print(print,String))
+                    )
+                )
+            )`
+
+            multiLevelTester('Test if number in list print', code, expectedTree, 6, 7);
+        })
+
+        describe('Test if number not in list print', () => {
+            const code = `if 5 not in list print 'in'`
+            const expectedTree =
+            `Program(
+                Command(
+                    If(
+                        if,
+                        Condition(NotInListCheck(Int,not_in,not_in,Text)),
+                        IfLessCommand(Print(print,String))
+                    )
+                )
+            )`
+
+            multiLevelTester('Test if number not in list print', code, expectedTree, 6, 7);
+        })
     })
 });

--- a/tests/cypress/e2e/lezer-tests/level_08.cy.js
+++ b/tests/cypress/e2e/lezer-tests/level_08.cy.js
@@ -1,0 +1,55 @@
+import { multiLevelTester, singleLevelTester } from "../tools/lezer/lezer_tester"
+
+describe('Lezer parser tests for level 8', () => {
+    describe('Successful tests', () => {
+        describe('Test if text in list print', () => {
+            const code = `
+            if text in list
+              print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(InListCheck(Text,in,Text)))),
+                Command(Print(print,String)))`
+
+            multiLevelTester('Test if text in list print', code, expectedTree, 8, 11);
+        })
+
+        describe('Test if number in list print', () => {
+            const code =
+            `if 5 in list
+                print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(InListCheck(Int,in,Text)))),
+                Command(Print(print,String))
+            )`
+
+            multiLevelTester('Test if number in list print', code, expectedTree, 8, 11);
+        })
+
+        describe('Test if text not in list print', () => {
+            const code = `
+            if text not in list
+              print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(NotInListCheck(Text,not_in,not_in,Text)))),
+                Command(Print(print,String)))`
+
+            multiLevelTester('Test if text not in list print', code, expectedTree, 8, 11);
+        })
+
+        describe('Test if number not in list print', () => {
+            const code =
+            `if 5 not in list
+                print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(NotInListCheck(Int,not_in,not_in,Text)))),
+                Command(Print(print,String))
+            )`
+
+            multiLevelTester('Test if number not in list print', code, expectedTree, 8, 11);
+        })
+    })
+})

--- a/tests/cypress/e2e/lezer-tests/level_12.cy.js
+++ b/tests/cypress/e2e/lezer-tests/level_12.cy.js
@@ -1,18 +1,100 @@
-import { multiLevelTester } from "../tools/lezer/lezer_tester";
+import { multiLevelTester, singleLevelTester } from "../tools/lezer/lezer_tester";
 
 describe('Tests level 12', () => {
-    describe('Test for Spanish', () => {
-        const code = 
-        `para animal en animales
-            imprimir 'Yo amo ' animal
-        `
-        
-        const expectedTree = `
-        Program(
-            Command(For(for,Text,in,Text)),
-            Command(Print(print,Expression(String),Expression(Text)))
-        )`
+    describe('Successful tests', () => {
+        describe('Test for Spanish', () => {
+            const code =
+            `para animal en animales
+                imprimir 'Yo amo ' animal
+            `
 
-        multiLevelTester('Test for Spanish', code, expectedTree, 12, 16, 'es');
+            const expectedTree = `
+            Program(
+                Command(For(for,Text,in,Text)),
+                Command(Print(print,Expression(String),Expression(Text)))
+            )`
+
+            multiLevelTester('Test for Spanish', code, expectedTree, 12, 16, 'es');
+        })
+
+        describe('Test if text in list print', () => {
+            const code = `
+            if text in list
+              print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(InListCheck(Text,in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if text in list print', code, expectedTree, 12, 13);
+        })
+
+        describe('Test if number in list print', () => {
+            const code =
+            `if 5 in list
+                print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(InListCheck(Number,in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if number in list print', code, expectedTree, 12, 13);
+        })
+
+        describe('Test if quoted text in list print', () => {
+            const code =
+            `if 'bird' in list:
+                print 'fly'
+            `
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(InListCheck(String,in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if quoted text in list print', code, expectedTree, 12, 13);
+        })
+
+        describe('Test if text not in list print', () => {
+            const code = `
+            if text not in list
+              print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(NotInListCheck(Text,not_in,not_in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if text not in list print', code, expectedTree, 12, 13);
+        })
+
+        describe('Test if number not in list print', () => {
+            const code =
+            `if 5 not in list
+                print 'in'`
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(NotInListCheck(Number,not_in,not_in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if number not in list print', code, expectedTree, 12, 13);
+        })
+
+        describe('Test if quoted text not in list print', () => {
+            const code =
+            `if 'bird' not in list:
+                print 'fly'
+            `
+            const expectedTree =
+            `Program(
+                Command(If(if,Condition(NotInListCheck(String,not_in,not_in,Text)))),
+                Command(Print(print,Expression(String)))
+            )`
+
+            multiLevelTester('Test if quoted text not in list print', code, expectedTree, 12, 13);
+        })
     })
 })

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -571,38 +571,109 @@ class TestsLevel16(HedyTester):
             extra_check_function=self.is_turtle(),
         )
 
-    def test_if_in_list_print(self):
-        code = textwrap.dedent("""\
+    #
+    # in/not-in list commands
+    #
+    @parameterized.expand([
+        ('in', 'Found'),
+        ('not in', 'Not found')
+    ])
+    def test_if_in_not_in_list_with_strings(self, command, expected_output):
+        code = textwrap.dedent(f"""\
             letters = ['a', 'b', 'c']
-            if 'a' in letters
-              print 'Found'""")
-
-        expected = textwrap.dedent("""\
-            letters = ['a', 'b', 'c']
-            if 'a' in letters:
-              print(f'''Found''')""")
-
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            output='Found'
-        )
-
-    def test_if_not_in_list_print(self):
-        code = textwrap.dedent("""\
-            letters = ['a', 'b', 'c']
-            if 'd' not in letters
+            if 'a' {command} letters
+              print 'Found'
+            else
               print 'Not found'""")
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(f"""\
             letters = ['a', 'b', 'c']
-            if 'd' not in letters:
+            if 'a' {command} letters:
+              print(f'''Found''')
+            else:
               print(f'''Not found''')""")
 
         self.single_level_tester(
             code=code,
             expected=expected,
-            output='Not found'
+            output=expected_output
+        )
+
+    @parameterized.expand([
+        ('in', 'True'),
+        ('not in', 'False')
+    ])
+    def test_if_number_in_not_in_list_with_numbers(self, operator, expected_output):
+        code = textwrap.dedent(f"""\
+        items is [1, 2, 3]
+        if 1 {operator} items
+          print 'True'
+        else
+          print 'False'""")
+
+        expected = textwrap.dedent(f"""\
+        items = [1, 2, 3]
+        if 1 {operator} items:
+          print(f'''True''')
+        else:
+          print(f'''False''')""")
+
+        self.single_level_tester(
+            code=code,
+            expected=expected,
+            output=expected_output
+        )
+
+    @parameterized.expand([
+        ('in', 'False'),
+        ('not in', 'True')
+    ])
+    def test_if_text_in_not_in_list_with_numbers(self, operator, expected_output):
+        code = textwrap.dedent(f"""\
+            items is [1, 2, 3]
+            if '1' {operator} items
+              print 'True'
+            else
+              print 'False'""")
+
+        expected = textwrap.dedent(f"""\
+            items = [1, 2, 3]
+            if '1' {operator} items:
+              print(f'''True''')
+            else:
+              print(f'''False''')""")
+
+        self.single_level_tester(
+            code=code,
+            expected=expected,
+            output=expected_output
+        )
+
+    @parameterized.expand(['in', 'not in'])
+    def test_unquoted_lhs_in_not_in_list_gives_error(self, operator):
+        code = textwrap.dedent(f"""\
+            items is [1, 2, 3]
+            if a {operator} items
+              print 'True'""")
+
+        self.single_level_tester(
+            code=code,
+            skip_faulty=False,
+            exception=hedy.exceptions.UnquotedAssignTextException,
+            extra_check_function=lambda c: c.exception.arguments['line_number'] == 2
+        )
+
+    @parameterized.expand(['in', 'not in'])
+    def test_undefined_rhs_in_not_in_list_gives_error(self, operator):
+        code = textwrap.dedent(f"""\
+            items is [1, 2, 3]
+            if 1 {operator} list
+              print 'True'""")
+
+        self.single_level_tester(
+            code=code,
+            exception=hedy.exceptions.UndefinedVarException,
+            extra_check_function=lambda c: c.exception.arguments['line_number'] == 2
         )
 
     #


### PR DESCRIPTION
Fixes #5083
- Fix incorrect result when checking whether a number is in/not-in a list starting from level 12
- Fix highlighting of left-hand-side arguments of in/not-in operators starting from level 6
- Fix broken tic-tac-toe adventure snippet in Shqip in level 14. It seems that one of the letters in the variable name was a Cyrillic 'e' instead of a Latin 'e'. This caused the program to not work correctly at runtime.

**How to test**
To test the corrected transpiling of the in/not-in operators:
- Ensure that the unit tests cover convert the left-hand-side argument of the operators, so that the original type is preserved.
- Run Hedy locally and navigate to level 12. Execute the following snippet and ensure that the output is 'Found' instead of 'Not found'
```
numbers = 1, 2, 3
if 1 in numbers
  print 'Found'
else
  print 'Not found'
```

To test the highlighting of the left-hand-side argument of the in/not-in operators:
- Ensure that the added highlighting tests cover the changes
- Run Hedy locally and input the following snippet in the editor for the specified level. Ensure that integers, quoted strings and variables are highlighted properly.
```
# level 6
numbers is a, b
if 1 in numbers print 'a'
if var in numbers print 'b'
```
```
# level 12
numbers is 'a', 'b'
var is 1
if 1 in numbers
  print 'a'
if var in numbers
  print 'b'
if 'test' in numbers
  print 'c'
```

To test the broken tic-tac-toe adventure snippet:
- Run Hedy locally and navigate to level 14 and select the Tic Tac Toe tab. Change the language to Shqip. Copy the sample snippet to the editor and run the program.
- Input any number from 1-9 and notice that your choice is reflected with an 'X' in the printed board.