### PR TITLE
🚚 redirect to hedy.org

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,6 +261,22 @@ cdn.Cdn(app, os.getenv('CDN_PREFIX'), os.getenv('HEROKU_SLUG_COMMIT', 'dev'))
 
 
 @app.before_request
+def redirect_outdated_domains():
+    """If Hedy is being loaded from a domain we no longer use or advertise,
+    do a 301 redirect to the official 'hedy.org' domain.
+
+    If we keep this up for long enough, eventually Google will update its index
+    to forget about the old domains.
+    """
+    # request.host looks like 'hostname[:port]'
+    host = request.host.split(':')[0]
+
+    if host in ['hedycode.com', 'hedy-beta.herokuapp.com']:
+        # full_path starts with '/' and has everything
+        return redirect(f'https://hedy.org{request.full_path}', code=301)
+
+
+@app.before_request
 def before_request_begin_logging():
     """Initialize the query logging.
 


### PR DESCRIPTION
Google is still indexing old domains for Hedy (`hedy-beta.herokuapp.com` and `hedycode.com`).

When Hedy is loaded from any of the old domains, do a redirect to the modern domain (`hedy.org`).

**How to test**

Locally, add `localhost` (or `127.0.0.1`, whichever one you use) to the list of redirected hosts, then load Hedy locally and observe that you get redirected to https://hedy.org/. Don't commit those changes 😉 