### PR TITLE
🪲 Update Gunicorn to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.3.2
 Werkzeug==3.0.1
 lark==1.1.1
-gunicorn==19.9.0
+gunicorn==21.2.0
 flask-compress==1.4.0
 requests==2.31.0
 attrs>=22.2.0


### PR DESCRIPTION
hedy-alpha is broken and the logs show this: 

```
2024-02-14T10:04:05.636232+00:00 heroku[web.1]: Process exited with status 1
2024-02-14T10:04:05.588655+00:00 app[web.1]: Traceback (most recent call last):
2024-02-14T10:04:05.588726+00:00 app[web.1]:   File "/app/.heroku/python/bin/gunicorn", line 5, in <module>
2024-02-14T10:04:05.588785+00:00 app[web.1]:     from gunicorn.app.wsgiapp import run
2024-02-14T10:04:05.588814+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.12/site-packages/gunicorn/app/wsgiapp.py", line 9, in <module>
2024-02-14T10:04:05.588907+00:00 app[web.1]:     from gunicorn.app.base import Application
2024-02-14T10:04:05.588930+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.12/site-packages/gunicorn/app/base.py", line 11, in <module>
2024-02-14T10:04:05.589016+00:00 app[web.1]:     from gunicorn._compat import execfile_
2024-02-14T10:04:05.589036+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.12/site-packages/gunicorn/_compat.py", line 264, in <module>
2024-02-14T10:04:05.589149+00:00 app[web.1]:     from gunicorn.six.moves.urllib.parse import urlsplit
2024-02-14T10:04:05.589186+00:00 app[web.1]: ModuleNotFoundError: No module named 'gunicorn.six.moves'
```

Which suggest us that perhaps the library version is too old and we need to also update it. Lets see!