### PR TITLE
🖊️ Show translated error when text input is passed to repeat command

### DIFF
--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -431,6 +431,14 @@ class HedyTester(unittest.TestCase):
         except IndexError:
           raise Exception('catch_index_exception')""")
 
+    @staticmethod
+    def variable_type_check_transpiled(variable, type_,):
+        return textwrap.dedent(f"""\
+        try:
+          {type_}({variable})
+        except ValueError:
+          raise Exception(f'catch_value_exception')""")
+
     # Used to overcome indentation issues when the above code is inserted
     # in test cases which use different indentation style (e.g. 2 or 4 spaces)
     @staticmethod

--- a/tests/test_level/test_level_07.py
+++ b/tests/test_level/test_level_07.py
@@ -56,11 +56,13 @@ class TestsLevel7(HedyTester):
         n is 5
         repeat n times print 'me wants a cookie!'""")
 
-        expected = textwrap.dedent("""\
-        n = '5'
-        for __i__ in range(int(n)):
-          print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = '5'",
+            self.variable_type_check_transpiled('n', 'int'),
+            "for __i__ in range(int(n)):",
+            ("print(f'me wants a cookie!')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         output = textwrap.dedent("""\
         me wants a cookie!
@@ -245,11 +247,13 @@ class TestsLevel7(HedyTester):
         n is ask 'How many times?'
         repeat n times print 'n'""")
 
-        expected = textwrap.dedent("""\
-        n = input(f'How many times?')
-        for __i__ in range(int(n)):
-          print(f'n')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = input(f'How many times?')",
+            self.variable_type_check_transpiled('n', 'int'),
+            "for __i__ in range(int(n)):",
+            ("print(f'n')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         self.single_level_tester(code=code, expected=expected)
 

--- a/tests/test_level/test_level_08.py
+++ b/tests/test_level/test_level_08.py
@@ -648,11 +648,13 @@ class TestsLevel8(HedyTester):
         repeat n times
             print 'me wants a cookie!'""")
 
-        expected = textwrap.dedent("""\
-        n = '5'
-        for i in range(int(n)):
-          print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = '5'",
+            self.variable_type_check_transpiled('n', 'int'),
+            "for i in range(int(n)):",
+            ("print(f'me wants a cookie!')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         output = textwrap.dedent("""\
         me wants a cookie!
@@ -681,11 +683,13 @@ class TestsLevel8(HedyTester):
         repeat n times
             print 'me wants a cookie!'""")
 
-        expected = textwrap.dedent("""\
-        n = '٥'
-        for i in range(int(n)):
-          print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = '٥'",
+            self.variable_type_check_transpiled('n', 'int'),
+            "for i in range(int(n)):",
+            ("print(f'me wants a cookie!')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         output = textwrap.dedent("""\
         me wants a cookie!
@@ -702,11 +706,13 @@ class TestsLevel8(HedyTester):
         repeat állatok times
             print 'me wants a cookie!'""")
 
-        expected = textwrap.dedent("""\
-        állatok = '5'
-        for i in range(int(állatok)):
-          print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "állatok = '5'",
+            self.variable_type_check_transpiled('állatok', 'int'),
+            "for i in range(int(állatok)):",
+            ("print(f'me wants a cookie!')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         output = textwrap.dedent("""\
         me wants a cookie!
@@ -796,11 +802,13 @@ class TestsLevel8(HedyTester):
         repeat n times
             print 'n'""")
 
-        expected = textwrap.dedent("""\
-        n = input(f'How many times?')
-        for i in range(int(n)):
-          print(f'n')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = input(f'How many times?')",
+            self.variable_type_check_transpiled('n', 'int'),
+            'for i in range(int(n)):',
+            ("print(f'n')", '  '),
+            ('time.sleep(0.1)', '  ')
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -1201,16 +1209,18 @@ class TestsLevel8(HedyTester):
         print 'Thank you for ordering!'
         print 'Enjoy your meal!'""")
 
-        expected_code = textwrap.dedent("""\
-        print(f'Welcome to Restaurant Chez Hedy!')
-        people = input(f'How many people will be joining us today?')
-        print(f'Great!')
-        for i in range(int(people)):
-          food = input(f'What would you like to order?')
-          print(f'{food}')
-          time.sleep(0.1)
-        print(f'Thank you for ordering!')
-        print(f'Enjoy your meal!')""")
+        expected_code = HedyTester.dedent(
+            "print(f'Welcome to Restaurant Chez Hedy!')",
+            "people = input(f'How many people will be joining us today?')",
+            "print(f'Great!')",
+            self.variable_type_check_transpiled('people', 'int'),
+            "for i in range(int(people)):",
+            ("food = input(f'What would you like to order?')", '  '),
+            ("print(f'{food}')", '  '),
+            ("time.sleep(0.1)", '  '),
+            "print(f'Thank you for ordering!')",
+            "print(f'Enjoy your meal!')"
+        )
 
         expected_source_map = {
             '1/1-1/41': '1/1-1/43',
@@ -1218,14 +1228,14 @@ class TestsLevel8(HedyTester):
             '2/1-2/57': '2/1-2/61',
             '3/1-3/15': '3/1-3/17',
             '4/8-4/14': '2/27-2/33',
-            '5/5-5/9': '5/1-5/5',
-            '5/5-5/47': '5/1-5/47',
+            '5/5-5/9': '9/1-9/5',
+            '5/5-5/47': '9/1-9/47',
             '6/11-6/15': '1/1-1/5',
-            '6/5-6/15': '6/1-6/17',
-            '4/1-6/24': '4/1-7/18',
-            '7/1-7/32': '8/1-8/34',
-            '8/1-8/25': '9/1-9/27',
-            '1/1-8/26': '1/1-9/27',
+            '6/5-6/15': '10/1-10/17',
+            '4/1-6/24': '4/1-11/18',
+            '7/1-7/32': '12/1-12/34',
+            '8/1-8/25': '13/1-13/27',
+            '1/1-8/26': '1/1-13/27',
         }
 
         self.single_level_tester(code, expected=expected_code)

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -1610,11 +1610,13 @@ class TestsLevel12(HedyTester):
         repeat n times
             print 'me wants a cookie!'""")
 
-        expected = textwrap.dedent("""\
-        n = 5
-        for i in range(int(n)):
-          print(f'''me wants a cookie!''')
-          time.sleep(0.1)""")
+        expected = HedyTester.dedent(
+            "n = 5",
+            self.variable_type_check_transpiled('n', 'int'),
+            "for i in range(int(n)):",
+            ("print(f'''me wants a cookie!''')", '  '),
+            ("time.sleep(0.1)", '  ')
+        )
 
         output = textwrap.dedent("""\
         me wants a cookie!


### PR DESCRIPTION
Fixes #2790

**How to test**

- Start hedy locally and navigate to level 7. Execute the following snippet and supply a non-numeric value as input. Ensure that there is a nice error translated correctly.
```
hoeveel is ask 'hoeveel?'
repeat hoeveel times print 'times'
```
- Repeat the same for level 8 and the following snippet:
```
hoeveel is ask 'hoeveel?'
repeat hoeveel times
    print 'times'
```

