### PR TITLE
🪲 Correctly filter teacher adventures in programs page

### DIFF
--- a/app.py
+++ b/app.py
@@ -872,8 +872,8 @@ def translate_list(args):
 
     if len(translated_args) > 1:
         return f"{', '.join(translated_args[0:-1])}" \
-               f" {gettext('or')} " \
-               f"{translated_args[-1]}"
+            f" {gettext('or')} " \
+            f"{translated_args[-1]}"
     return ''.join(translated_args)
 
 
@@ -994,15 +994,22 @@ def programs_page(user):
         public_profile = DATABASE.get_public_profile_settings(username)
 
     keyword_lang = g.keyword_lang
-    adventure_names = hedy_content.Adventures(g.lang).get_adventure_names(keyword_lang)
-    swapped_adventure_names = {value: key for key, value in adventure_names.items()}
 
+    adventure_names = hedy_content.Adventures(g.lang).get_adventure_names(keyword_lang)
     level = request.args.get('level', default=None, type=str) or None
     adventure = request.args.get('adventure', default=None, type=str) or None
     page = request.args.get('page', default=None, type=str)
     filter = request.args.get('filter', default=None, type=str)
     submitted = True if filter == 'submitted' else None
 
+    all_programs = DATABASE.filtered_programs_for_user(from_user or username,
+                                                       submitted=submitted,
+                                                       pagination_token=page)
+
+    for program in all_programs:
+        adventure_names[program['adventure_name']] = program['name']
+
+    swapped_adventure_names = {value: key for key, value in adventure_names.items()}
     result = DATABASE.filtered_programs_for_user(from_user or username,
                                                  level=level,
                                                  adventure=swapped_adventure_names.get(adventure),
@@ -1029,14 +1036,10 @@ def programs_page(user):
              }
         )
 
-    all_programs = DATABASE.filtered_programs_for_user(from_user or username,
-                                                       submitted=submitted,
-                                                       pagination_token=page)
-
-    sorted_level_programs = hedy_content.Adventures(
-        g.lang).get_sorted_level_programs(all_programs, adventure_names)
-    sorted_adventure_programs = hedy_content.Adventures(
-        g.lang).get_sorted_adventure_programs(all_programs, adventure_names)
+    sorted_level_programs = hedy_content.Adventures(g.lang)\
+                                        .get_sorted_level_programs(all_programs, adventure_names)
+    sorted_adventure_programs = hedy_content.Adventures(g.lang)\
+                                            .get_sorted_adventure_programs(all_programs, adventure_names)
 
     next_page_url = url_for('programs_page', **dict(request.args, page=result.next_page_token)
                             ) if result.next_page_token else None

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -531,9 +531,9 @@ class Adventures(StructuredDataFile):
         sort = {}
         for program in programs_by_level:
             if program['level'] in sort:
-                sort[program['level']].append(adventure_names.get(program['adventure_name']))
+                sort[program['level']].append(adventure_names.get(program['adventure_name'], program['adventure_name']))
             else:
-                sort[program['level']] = [adventure_names.get(program['adventure_name'])]
+                sort[program['level']] = [adventure_names.get(program['adventure_name'], program['adventure_name'])]
         for level, adventures in sort.copy().items():
             sort[level] = sorted(adventures, key=lambda s: s.lower())
 
@@ -543,7 +543,7 @@ class Adventures(StructuredDataFile):
         programs_by_adventure = []
         for item in programs:
             programs_by_adventure.append(
-                {'adventure_name': adventure_names.get(item.get('adventure_name')),
+                {'adventure_name': adventure_names.get(item.get('adventure_name'), item.get('adventure_name')),
                  'level': item['level'],
                  }
             )


### PR DESCRIPTION
Adds the teacher adventure's names to the `adventure_names` dictionary, preventing a bug that was causing the `/programs`  page to crash. Also adds a bit of defensive programming around the use of that dictionary, in case in the future we have a problem in the content or in the adventures from the DB.

**How to test**
* Log in as a student that has a program saved which comes from a teacher adventure and go to My programs page. Check that the page works correctly and doesn't crash.

