### PR TITLE
🪲 Fix old programs in program page, improve filtering teacher programs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1005,10 +1005,15 @@ def programs_page(user):
     all_programs = DATABASE.filtered_programs_for_user(from_user or username,
                                                        submitted=submitted,
                                                        pagination_token=page)
-
+    ids_to_fetch = []
     for program in all_programs:
-        adventure_names[program['adventure_name']] = program['name']
+        if 'adventure_name' in program and program['adventure_name'] not in adventure_names:
+            ids_to_fetch.append(program['adventure_name'])
 
+    teacher_adventures = DATABASE.batch_get_adventures(ids_to_fetch)
+    for id, teacher_adventure in teacher_adventures.items():
+        if teacher_adventure is not None:
+            adventure_names[id] = teacher_adventure['name']
     swapped_adventure_names = {value: key for key, value in adventure_names.items()}
     result = DATABASE.filtered_programs_for_user(from_user or username,
                                                  level=level,

--- a/templates/htmx-program.html
+++ b/templates/htmx-program.html
@@ -16,7 +16,7 @@
                 <td>{{program.name|truncate(30)}}</td>
                 <td>{{_('level')}} {{ program.level }}</td>
                 {% if program.adventure_name %}
-                    <td>{{adventure_names.get(program.adventure_name)}}</td>
+                    <td>{{adventure_names.get(program.adventure_name, program.adventure_name)}}</td>
                 {% else %}
                     <td>-</td>
                 {% endif %}


### PR DESCRIPTION
Same thing happened to us back in #4417. Some old programs don't have the field `adventure_name` in them, and thus our systems fails. I also improve a bit the filtering of programs, by not using the program name, but rather the adventure name.

I also have a question, what to do with programs that might have an id that's neither in the DB or our own contents? Right now, Im resorting to just show the id, but perhaps we should skip them? What do you think?

![image](https://github.com/hedyorg/hedy/assets/45865185/dd65b538-960d-40da-a02f-a2f4336daa7d)


**How to test**

Go to My Programs page, it should be working. 

If you want to see a program with a non-existing adventure linked, copy an existing `program` record in the dev_dabase.json and change the `adventure_name` field to something that's not present in the database.
