### PR TITLE
🚚 Prevent the endless update train when fix script reports errors

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -115,7 +115,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: comment.md.tmp
-        comment_tag: updates
 
     #----------------------------------------------------------------------
     #  Commit back

--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -103,18 +103,18 @@ jobs:
         doit run _autopr_weblate
 
     - name: Prepare comment
-      if: ${{ hashFiles('snippet-report.txt') != '' }}
+      if: ${{ hashFiles('snippet-report.md.tmp') != '' }}
       run: |
-        echo 'The automatic script made changes' >> comment.txt
-        echo '```' >> comment.txt
-        cat snippet-report.txt >> comment.txt
-        echo '```' >> comment.txt
+        echo 'The automatic script made changes' >> comment.md.tmp
+        echo '```' >> comment.md.tmp
+        cat snippet-report.md.tmp >> comment.md.tmp
+        echo '```' >> comment.md.tmp
 
     - name: Post comment
-      if: ${{ hashFiles('comment.txt') != '' && github.event_name == 'pull_request_target' }}
+      if: ${{ hashFiles('comment.md.tmp') != '' && github.event_name == 'pull_request_target' }}
       uses: thollander/actions-comment-pull-request@v2
       with:
-        filePath: comment.txt
+        filePath: comment.md.tmp
         comment_tag: updates
 
     #----------------------------------------------------------------------

--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -115,6 +115,7 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: comment.txt
+        comment_tag: updates
 
     #----------------------------------------------------------------------
     #  Commit back

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ dist/
 
 # hide file_logger.json
 file_logger.json
+./*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,4 @@ dist/
 
 # hide file_logger.json
 file_logger.json
-./*.txt
+*.tmp

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,3 @@ doit==0.36.0
 doit_watch>=0.1.0
 uflash>=2.0.0
 pyinstaller==6.3.0
-wlc

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ doit==0.36.0
 doit_watch>=0.1.0
 uflash>=2.0.0
 pyinstaller==6.3.0
+wlc

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -520,7 +520,7 @@ class HedyTester(unittest.TestCase):
 
         return snippets
 
-    def format_test_error(self, E, snippet):
+    def format_test_error(self, E, snippet: Snippet):
         """Given a snippet and an exception, return a string describing the problem."""
         message = []
 
@@ -547,7 +547,7 @@ class HedyTester(unittest.TestCase):
             return '\n'.join(lines).strip()
 
         message.append('======================================================================')
-        message.append(f'Language {snippet.language}, level {snippet.level} produces an error:')
+        message.append(f'{snippet.filename}: snippet in level {snippet.level} produces an error:')
         message.append(f'{error_message} at line {location}')
         message.append('-- keywords --')
         message.append(add_arrow(snippet.original_code))

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -520,8 +520,8 @@ class HedyTester(unittest.TestCase):
 
         return snippets
 
-    def format_test_error(self, E, snippet: Snippet):
-        """Given a snippet and an exception, return a string describing the problem."""
+    def format_test_error_md(self, E, snippet: Snippet):
+        """Given a snippet and an exception, return a Markdown string describing the problem."""
         message = []
 
         arrow = True  # set to False if you want to remove the <---- in the output f.e. for easy copy-pasting
@@ -546,13 +546,20 @@ class HedyTester(unittest.TestCase):
                      for i, line in enumerate(lines)]
             return '\n'.join(lines).strip()
 
-        message.append('======================================================================')
-        message.append(f'{snippet.filename}: snippet in level {snippet.level} produces an error:')
-        message.append(f'{error_message} at line {location}')
-        message.append('-- keywords --')
+        message.append(f'## {snippet.filename}: snippet in level {snippet.level}')
+
+        # Use a 'caution' admonition because it renders in red
+        message.append('> [!CAUTION]')
+        message.append(f'> {error_message} at line {location}')
+
+        message.append('\nTranslation source')
+        message.append('```')
         message.append(add_arrow(snippet.original_code))
-        message.append('-- translated --')
+        message.append('```')
+        message.append('\nTranslated version')
+        message.append('```')
         message.append(add_arrow(snippet.code))
+        message.append('```')
 
         return '\n'.join(message)
 

--- a/tests/test_snippets/snippet_tester.py
+++ b/tests/test_snippets/snippet_tester.py
@@ -223,14 +223,14 @@ class HedySnippetTester(HedyTester):
         except OSError:
             return None  # programs with ask cannot be tested with output :(
         except exceptions.HedyException as E:
-            error_message = self.format_test_error(E, snippet)
+            error_message = self.format_test_error_md(E, snippet)
 
             if fix_error and yaml_locator:
                 self.restore_snippet_to_english(snippet, yaml_locator)
 
-                with open(path.join(rootdir(), 'snippet-report.txt'), 'a') as f:
+                with open(path.join(rootdir(), 'snippet-report.md.txt'), 'a') as f:
                     f.write(error_message + '\n')
-                    f.write('*** This snippet has been reverted to English ***\n\n')
+                    f.write('This snippet has been reverted to English.\n\n')
             else:
                 print(error_message)
                 raise E

--- a/tests/test_snippets/snippet_tester.py
+++ b/tests/test_snippets/snippet_tester.py
@@ -228,7 +228,7 @@ class HedySnippetTester(HedyTester):
             if fix_error and yaml_locator:
                 self.restore_snippet_to_english(snippet, yaml_locator)
 
-                with open(path.join(rootdir(), 'snippet-report.md.txt'), 'a') as f:
+                with open(path.join(rootdir(), 'snippet-report.md.tmp'), 'a') as f:
                     f.write(error_message + '\n')
                     f.write('This snippet has been reverted to English.\n\n')
             else:


### PR DESCRIPTION
The problem was that the script would write to a `.txt` file, which would subsequently get committed and trigger another update which would post again, etc.

Fixed by writing to `.md.tmp` files, and gitignoring `.tmp` files. While we're at it, make the comment a bit nicer to read as well by outputting MarkDown instead of plain text.