### PR TITLE
🚚 Fix parameters to "create PR action" in Weblate merge conflict workflow

### DIFF
--- a/.github/workflows/resolve-weblate-conflict.yml
+++ b/.github/workflows/resolve-weblate-conflict.yml
@@ -75,7 +75,7 @@ jobs:
         tools/merge-weblate-resolving-conflicts.sh
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3.10.0
+      uses: peter-evans/create-pull-request@v6
       with:
         # token: ${{ steps.secret.outputs.secret }}
         # Let's see if the GitHub Token suffices
@@ -86,3 +86,5 @@ jobs:
           with changes on `main`.
         labels: translations
         branch: automatic/weblate-conflicts
+        delete-branch: true
+        base: main


### PR DESCRIPTION
We weren't using version 6, and needed to set the correct base branch.