### PR TITLE
🚚 Stop normalizing YAML and PO files

### DIFF
--- a/build-tools/github/restore-po-header.py
+++ b/build-tools/github/restore-po-header.py
@@ -2,6 +2,7 @@
 # Between 2 PO files, copy the header (and only the header) from one to the other.
 import sys
 
+
 def find_po_header(lines):
     """Find the po header, starting from 'msgid ""' to the next empty line."""
     start = None
@@ -21,7 +22,6 @@ if __name__ == '__main__':
 
     src_header = find_po_header(src)
     dst_header = find_po_header(dst)
-
 
     if src_header and dst_header:
         dst[dst_header[0]:dst_header[1]] = src[src_header[0]:src_header[1]]

--- a/build-tools/github/restore-po-header.py
+++ b/build-tools/github/restore-po-header.py
@@ -1,0 +1,39 @@
+# /usr/bin/env python3
+# Between 2 PO files, copy the header (and only the header) from one to the other.
+import sys
+
+def find_po_header(lines):
+    """Find the po header, starting from 'msgid ""' to the next empty line."""
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == 'msgid ""':
+            start = i
+        if start is not None and line.strip() == '':
+            return (start, i + 1)
+    return None
+
+
+if __name__ == '__main__':
+    with open(sys.argv[1]) as src_file:
+        src = src_file.read().split('\n')
+    with open(sys.argv[2]) as dst_file:
+        dst = dst_file.read().split('\n')
+
+    src_header = find_po_header(src)
+    dst_header = find_po_header(dst)
+
+
+    if src_header and dst_header:
+        dst[dst_header[0]:dst_header[1]] = src[src_header[0]:src_header[1]]
+
+        # Apart from the header, we also mimic the trailing newline style of the source file
+        src_trailing = src[-1] == ''
+        dst_trailing = dst[-1] == ''
+
+        if src_trailing and not dst_trailing:
+            dst.append('')
+        if not src_trailing and dst_trailing:
+            dst.pop()
+
+        with open(sys.argv[2], 'w') as dst_file:
+            dst_file.write('\n'.join(dst))

--- a/dodo.py
+++ b/dodo.py
@@ -287,13 +287,33 @@ def task_lezer_parsers():
 
 
 def task_extract():
-    """Extract new translateable keys from the code."""
+    """Extract new translateable keys from the code.
+
+    To avoid merge conflicts with Weblate as much as possible, we will avoid
+    updating the PO file header (which usually contains metadata like
+    timestamps etc) -- this is likely to lead to conflicts when both Weblate
+    and this script have updated the PO files at the same time.
+    """
+    restore_po_header = 'build-tools/github/restore-po-header.py'
     return dict(
         title=lambda _: 'Extract new keys from the code',
         actions=[
+            # Save current files
+            'cp messages.pot messages.pot.tmp',
+            *[f'cp {pofile} {pofile}.tmp' for pofile in pofiles],
+
+            # Extract
             'pybabel extract -F babel.cfg -o messages.pot . --no-location --sort-output',
             'pybabel update -i messages.pot -d translations -N --no-wrap',
+
+            # Restore headers, remove tempfiles
+            [python3, restore_po_header, 'messages.pot.tmp', 'messages.pot'],
+            'rm messages.pot.tmp',
+            *[[python3, restore_po_header, f'{pofile}.tmp', pofile] for pofile in pofiles],
+            *[f'rm {pofile}.tmp' for pofile in pofiles],
         ],
+        # These commands print a bunch of progress to stderr that looks intimidating
+        verbosity=0,
     )
 
 
@@ -418,8 +438,10 @@ def task__autopr():
     This runs some tasks, mostly around translation, that contributors should
     run on their machines but tend to forget. That's what machines are for!
 
-    Running 'extract' and 'compile' has the benefit that it will unwrap
-    any files that were wrapped by Weblate.
+    We used to run heavy normalization over the translation files here. However,
+    if we do that Weblate will nearly always be in a state of conflicts, which
+    leads to scary warnings. Instead, we let Weblate decide what these files
+    should look like.
     """
 
     return dict(
@@ -428,11 +450,13 @@ def task__autopr():
             'extract',
             'backend',
             'frontend',
-            'normalize_yaml',
+            # No normalization for now!
+            # 'normalize_yaml',
         ],
         actions=[
+            # No normalization for now!
             # Run a script to strip things that lead to conflicts from po files
-            [python3, 'build-tools/github/normalize-pofiles.py'],
+            # [python3, 'build-tools/github/normalize-pofiles.py'],
         ])
 
 
@@ -444,6 +468,9 @@ def task__autopr_weblate():
 
     These are separate from normal autofixes because unit tests may take a long time
     to run, and we don't want to hold up normal PRs.
+
+    This script can produce a `.tmp.md` file reporting reverted snippets. When run from
+    GitHub Actions, the result will be posted to the PR as a comment.
     """
     os.environ['FIX_FOR_WEBLATE'] = '1'
     return dict(


### PR DESCRIPTION
Our plans to finagle Weblate into committing only once per day to reduce conflicts, allowing us to heavily normalize the translation files, has failed. Weblate is going to commit constantly, and it will have created files with the headers, wrapping, and key ordering that it has decided on its end. Any of our attempts to reformat those files will just lead to merge conflicts.

Instead: turn off YAML and POfile formatting; instead what we do to minimize the chances of conflicts is to stop PyBabel from updating PO file headers. Only Weblate is allowed to update those headers.
