### PR TITLE
🚚 Simplify test partitioning

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -51,11 +51,11 @@ jobs:
     - name: Run weblate tests
       shell: pwsh
       id: weblate_tests
-      if: ${{ github.event.pull_request.user.login == 'weblate' }}
+      if: github.event.pull_request.user.login == 'weblate'
       run: |
         build-tools/github/validate --weblate
     - name: Run all tests
       shell: pwsh
-      if: ${{ ((github.event.pull_request.user.login != 'weblate') || github.event.label.name == 'force_tests') }}
+      if: github.event.pull_request.user.login != 'weblate'
       run: |
-        build-tools/github/validate --all
+        build-tools/github/validate

--- a/build-tools/github/validate
+++ b/build-tools/github/validate
@@ -8,9 +8,7 @@ scriptdir=$(cd $(dirname $0) && pwd)
 # TODOs about extracting by JW 2023-10-03 for PR #4574
 $scriptdir/validate-typescript # TODO extract
 $scriptdir/validate-yaml # TODO extract
-if [[ "${1:-}" == "--all" ]]; then
-  $scriptdir/validate-tests --all
-elif [[ "${1:-}" == "--weblate" ]]; then
+if [[ "${1:-}" == "--weblate" ]]; then
   $scriptdir/validate-tests --weblate
 else
   $scriptdir/validate-tests

--- a/build-tools/github/validate-tests
+++ b/build-tools/github/validate-tests
@@ -9,13 +9,15 @@ python content/yaml_to_lark_utils.py
 
 echo "------> Python unit tests"
 
+
+# test_snippets (~20,000 tests) are only run for Weblate PRs.
+slow_suites=test_highlighting,test_level,test_translation_level,test_snippet
+
 # This is expected to run from the repo root
-if [[ "${1:-}" == "--all" ]]; then
-  python -m pytest -n 2
-elif [[ "${1:-}" == "--weblate" ]]; then
-  python -m pytest tests/test_snippets/test_adventures.py -s --tb=no -rN
-  python -m pytest tests/test_snippets/test_cheatsheets.py -s --tb=no -rN
-  python -m pytest tests/test_snippets/test_parsons.py -s --tb=no -rN
-else
-  python -m pytest --ignore=tests/test_highlighting --ignore=tests/test_level --ignore=tests/test_snippets --ignore=tests/test_translation_level
+#
+eval python -m pytest -n 2 --ignore=tests/{$slow_suites}
+
+if [[ "${1:-}" == "--weblate" ]]; then
+  # Add in the slow suites
+  eval python -m pytest -n 2 {$slow_suites} --tb=no -rN
 fi

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -168,8 +168,8 @@ class TestsLevel12(HedyTester):
 
     def test_print_subtraction_with_text(self):
         code = "print 'And the winner is ' 5 - 5"
-        expected = f"print(f'''And the winner is {{{self.number_cast_transpiled(
-            5)} - {self.number_cast_transpiled(5)}}}''')"
+        five = self.number_cast_transpiled(5)
+        expected = f"print(f'''And the winner is {{{five} - {five}}}''')"
         output = 'And the winner is 0'
 
         self.multi_level_tester(max_level=17, code=code, expected=expected, output=output)
@@ -1561,7 +1561,7 @@ class TestsLevel12(HedyTester):
         a is 1
         if a is 1
             print a
-        else    
+        else
             print 'nee'""")
 
         expected = textwrap.dedent("""\
@@ -1906,8 +1906,10 @@ class TestsLevel12(HedyTester):
         ('-', '-', '3')])
     def test_nested_int_calc(self, op, transpiled_op, output):
         code = f"print 10 {op} 5 {op} 2"
-        expected = f"print(f'''{{{self.number_cast_transpiled(10)} {transpiled_op} {
-            self.number_cast_transpiled(5)} {transpiled_op} {self.number_cast_transpiled(2)}}}''')"
+        ten = self.number_cast_transpiled(10)
+        five = self.number_cast_transpiled(5)
+        two = self.number_cast_transpiled(2)
+        expected = f"print(f'''{{{ten} {transpiled_op} {five} {transpiled_op} {two}}}''')"
 
         self.multi_level_tester(code=code, unused_allowed=True, expected=expected, output=output, max_level=17)
 
@@ -1940,8 +1942,8 @@ class TestsLevel12(HedyTester):
     @parameterized.expand(['-', '*', '/'])
     def test_print_float_calc_with_string(self, op):
         code = f"print 'het antwoord is ' 2.5 {op} 2.5"
-        expected = f"print(f'''het antwoord is {{{self.number_cast_transpiled('2.5')} {
-            op} {self.number_cast_transpiled('2.5')}}}''')"
+        twona_half = self.number_cast_transpiled('2.5')
+        expected = f"print(f'''het antwoord is {{{twona_half} {op} {twona_half}}}''')"
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
@@ -2251,7 +2253,7 @@ class TestsLevel12(HedyTester):
         code = textwrap.dedent("""\
         x = 'PRINT'
         x is button
-        if PRINT is pressed 
+        if PRINT is pressed
             print 'The button got pressed!'
         else
             print 'Other button is pressed!'""")
@@ -2285,7 +2287,7 @@ class TestsLevel12(HedyTester):
 
     def test_if_button_is_pressed_print_in_repeat(self):
         code = textwrap.dedent("""\
-        x = 'but' 
+        x = 'but'
         x is button
         repeat 3 times
             if but is pressed


### PR DESCRIPTION
There used to be 3 modes of running the tests:

* Normal
* With `--all` flag (only on non-Weblate PRs)
* With `--weblate` (only on Weblate PRs)

The result was that that the test suites:

    tests/test_highlighting
    tests/test_level
    tests/test_translation_level

Would not be run on Weblate PRs, and not locally.

Simplify the logic a bit by dividing the tests into 2 classes:

- Normal tests, always run
- Slow tests, run on Weblate PRs