### PR TITLE
Trigger a Weblate reset after pushing translations

### DIFF
--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -27,11 +27,17 @@ jobs:
         echo '[keys]' >> .weblate
         echo 'https://hosted.weblate.org/api/ = ${{ secrets.WEBLATE_API_KEY }}' >> .weblate
     - name: Weblate commands
+      # Do a weblate pull, commit and push.
+      # After pushing, clean the Weblate remote. This is necessary because we squash merge the
+      # commits that Weblate pushes, and if the bytes aren't exactly equivalent (for example
+      # if we wrap or we revert a broken bit of code) it will trigger a merge
+      # conflict.
       run: |
         set -x
         wlc repo
         wlc pull
         wlc commit
         wlc push
+        wlc reset
 
 


### PR DESCRIPTION
After we have told Weblate to push all of its pending commits, it should forget about them.

The reason is that we may revert some code samples, and when the translations PR finally squash-merges its way onto `main` and gets back to Weblate, it will see a conflict with its own pending changes.

By resetting, it will forget about its own pending changes, and consume the changes when they finally come in from the upstream repo.

This probably leads to an inconsistency window in which it looks for about ~1hr like the changes have disappeared. Fear not, they haven't, they will come back once the PR is in and Weblate syncs from the main repo.