### PR TITLE
🪲 fix go-back to class undefined

### DIFF
--- a/templates/customize-class/partial-sortable-adventures.html
+++ b/templates/customize-class/partial-sortable-adventures.html
@@ -87,11 +87,12 @@
                 {% endfor %}
         </div>
     </div>
-        <script>
-                if (window.hedyApp) {
-                    hedyApp.initializeCustomizeClassPage({
-                        level:  '{{  level }}',
-                    })
-                }
-        </script>
+    <script>
+        if (window.hedyApp) {
+            hedyApp.initializeCustomizeClassPage({
+                level:  '{{  level }}',
+                class_id: '{{ class_id }}',
+            })
+        }
+    </script>
 </div> 


### PR DESCRIPTION
Fixes #5263 

The problem was that we didn't pass the class_id argument to the function that allows teachers to go back to their class.