### PR TITLE
🪲 Fixes adventure translation

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,8 +236,12 @@ def load_customized_adventures(level, customizations, into_adventures):
 
     adventure_ids = {a['name'] for a in order_for_this_level if a['from_teacher']}
     teacher_adventure_map = DATABASE.batch_get_adventures(adventure_ids)
-    builtin_adventure_map = {a.short_name: a for a in into_adventures}
+    # Make a deepcopy if working locally, otherwise the local database values
+    # are by-reference and overwritten
+    if not os.getenv('NO_DEBUG_MODE'):
+        teacher_adventure_map = copy.deepcopy(teacher_adventure_map)
 
+    builtin_adventure_map = {a.short_name: a for a in into_adventures}
     # Replace `into_adventures`
     into_adventures[:] = []
     for a in order_for_this_level:

--- a/website/frontend_types.py
+++ b/website/frontend_types.py
@@ -143,7 +143,8 @@ class Adventure:
 
     @staticmethod
     def from_teacher_adventure_database_row(row):
-        text, example_code = halve_adventure_content(row["content"])
+        content = row['formatted_content'] if 'formatted_content' in row else row['content']
+        text, example_code = halve_adventure_content(content)
         return Adventure(
             short_name=row['id'],
             name=row['name'],


### PR DESCRIPTION
This PR actually solves two problems: first, that it wasn't possible for students to translate the keywords in the teacher adventures, due to the improper field being used to fetch the content of the database, and second, the local database was changed when translating the adventures.

This second issue was what caused this problem to be so hard to debug, since I didn't know if my fix actually worked, because the fields in the database were being changed. The actual problem here was that we were modifying a map from the database, and as @rix0rrr suggested, it was necessary to deep copy it so the fields weren't modified on our local copy.

Fixes #5328

**How to test**

* Create a new adventure, or save again `adventure1` logged in as teacher1
* Log in as student1 and select a keyword language other than English
* Check that the adventure can be translated back and forth and that the local database is not modifed by this.
