### PR TITLE
🧪 Profile live statistics page

### DIFF
--- a/website/statistics.py
+++ b/website/statistics.py
@@ -491,7 +491,7 @@ class LiveStatisticsModule(WebsiteModule):
             if programs_for_student != []:
                 attempted_adventures[level] = programs_for_student
         end = timer()
-        logger.debug(f'Time taken by get_class_live_stats {start-end}')
+        logger.debug(f'Time taken by get_class_live_stats {end-start}')
         return students, common_errors, selected_levels, quiz_info, attempted_adventures, adventures
 
     @route("/live_stats/class/<class_id>/select_level", methods=["GET"])


### PR DESCRIPTION
Adds a sort of profiling to this page by placing some timers in some key function where I think the slowdown happens. Why is it so hacky? I tried for several hours to use werkzeug's `ProfilerMiddleware` but I think there's a bug with the implementation, as several people have reported in some other tools: https://github.com/jazzband/django-debug-toolbar/issues/1875, https://github.com/jazzband/django-silk/issues/682

I thought that since we didn't need the full-fledged tool and didn't want to spend more time on this, this approach would suffice. 

