### PR TITLE
🧪 🪲 Fix flaky public program test

### DIFF
--- a/tests/cypress/e2e/public_programs/programs_page.cy.js
+++ b/tests/cypress/e2e/public_programs/programs_page.cy.js
@@ -39,7 +39,12 @@ describe("General tests for my programs page (with both custom teacher and built
     });
 
     it('can favourite and unfavourite a public program', () => {
+        cy.intercept({
+            url: '/auth/public_profile',
+            method: "POST"
+        }).as('public_profile')
         makeProfilePublic();
+        cy.wait('@public_profile')
         cy.visit(`${Cypress.env('programs_page')}`);
         cy.get(`[data-name=${programName}]`)
             .first()


### PR DESCRIPTION
Adds an intercept for the public profile call, which I think is the cause behind the flakiness. 


