### PR TITLE
🚚 Prevent Weblate Update workflow from overwriting existing PR

### DIFF
--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -18,7 +18,8 @@ jobs:
     # new changes over the unmerged old changes, causing them to lost.
     - name: Check for existence of old Weblate PR
       run: |
-        if [[ "$(gh pr -R hedyorg/hedy list --search 'Translations update' --json number)" != "[]" ]]; then
+        prs=$(gh pr -R hedyorg/hedy list -q '.[] | select(.title | contains("Translations update"))' --json title)
+        if [[ "$prs" != "" ]]; then
           echo "Open Pull Request for Weblate!"
           gh pr -R hedyorg/hedy list --search 'Translations update'
           exit 1

--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # If an open Weblate/translations PR still exists, we shouldn't tell Weblate to push again.
+    # Because we ended our previous push with a 'reset', Weblate would otherwise force-push
+    # new changes over the unmerged old changes, causing them to lost.
+    - name: Check for existence of old Weblate PR
+      run: |
+        if [[ "$(gh pr -R hedyorg/hedy list --search 'Translations update' --json number)" != "[]" ]]; then
+          echo "Open Pull Request for Weblate!"
+          gh pr -R hedyorg/hedy list --search 'Translations update'
+          exit 1
+        fi
     - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
@@ -38,6 +48,10 @@ jobs:
         wlc pull
         wlc commit
         wlc push
-        wlc reset
+        # On our repo, 'wlc reset' consistently times out the TCP connection after waiting
+        # for 5 minutes. The actual reset does seem to work, so we just don't wait for the
+        # command to finish, otherwise all our workflow executions show errors.
+        wlc reset &
+        sleep 10
 
 


### PR DESCRIPTION
If an open Weblate/translations PR still exists, we shouldn't tell Weblate to push again.  Because we ended our previous push with a 'reset', Weblate would otherwise force-push new changes over the unmerged old changes, causing them to lost.

**How to test**

After merging:

* Reopen an old Weblate PR
* Run the "update weblate" workflow on-demand
* Observe that it errors out and doesn't overwrite the old PR with new changes.