### PR TITLE
💻 Help us translate buttons

### DIFF
--- a/build-tools/heroku/tailwind/styles.css
+++ b/build-tools/heroku/tailwind/styles.css
@@ -382,6 +382,12 @@ code {
   @apply text-green-600;
 }
 
+.add-language-item {
+  @apply text-gray-800 bg-orange-300 no-underline hover:bg-orange-400 py-2 px-4 block whitespace-nowrap;
+  @apply cursor-pointer w-52 font-medium rounded-md;
+  @apply grow-0;
+}
+
 .dropdown-item {
   @apply text-gray-800 no-underline hover:bg-blue-600 py-2 px-4 block whitespace-nowrap;
   @apply cursor-pointer w-52 font-medium rounded-md;

--- a/messages.pot
+++ b/messages.pot
@@ -749,6 +749,9 @@ msgstr ""
 msgid "hello_logo"
 msgstr ""
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr ""
 

--- a/templates/incl/menubar.html
+++ b/templates/incl/menubar.html
@@ -64,6 +64,7 @@
                 {% for lang in other_languages() %}
                     <div class="dropdown-item language" onclick="hedyApp.change_language ('{{lang.lang}}');event.preventDefault();" data-cy="switch-lang-{{lang.lang}}">{{ lang.sym }}</div>
                 {% endfor %}
+                <a class="add-language-item language" href="https://hosted.weblate.org/new-lang/hedy/adventures/">{{_('help_us_translate')}}</a>
               </div>
           </div>
       </li>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -118,6 +118,7 @@
                         <option value="{{language.lang}}">{{language.sym}}</option>
                     {% endfor %}
                 </select>
+                <a class="ml-2 px-1 py-1 flex btn-shape green-btn items-center" href="https://hosted.weblate.org/new-lang/hedy/adventures/">{{_('help_us_translate')}}</a>
             </div>
             <div class="flex flex-row items-center mb-2" id="keyword_lang_container"
                  {% if user_data and 'language' in user_data and (user_data['language'] not in keyword_languages_keys() or user_data['language'] == "en") %}style="display: none;"{% endif %}>
@@ -153,7 +154,9 @@
                 </select>
             </div>
         </form>
-        <button class="red-btn" onclick="hedyApp.destroy('{{_('are_you_sure')}}')" id="delete_profile_button">{{_('destroy_profile')}}</button>
+        <div class="flex flex-row gap-2">
+            <button class="red-btn" onclick="hedyApp.destroy('{{_('are_you_sure')}}')" id="delete_profile_button">{{_('destroy_profile')}}</button>
+        </div>
        </div>
       <h1 id="password_toggle" class="section-header" onclick="$ ('#change-password-body').toggle()">{{_('change_password')}}</h1>
         <div class="profile-section-body" id="change-password-body">

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -862,6 +862,9 @@ msgstr "بدء الدليل التوجيهي"
 msgid "hello_logo"
 msgstr "مرحبا!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "مخفي"
 

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -960,6 +960,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Здравей"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -993,6 +993,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -799,6 +799,9 @@ msgstr "Icona del tutorial d'Hedy"
 msgid "hello_logo"
 msgstr "hola"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Ocult"
 

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -960,6 +960,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Ahoj!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -993,6 +993,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -993,6 +993,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -799,6 +799,9 @@ msgstr "Hedy Anleitung Symbol"
 msgid "hello_logo"
 msgstr "hallo"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Versteckt"
 

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -889,6 +889,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Γεια!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Κρυμμένο"
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -750,6 +750,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr "Help us translate"
+
 msgid "hidden"
 msgstr "Hidden"
 

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -894,6 +894,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Saluton!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Kaŝita"
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -752,6 +752,9 @@ msgstr "Icono de tutorial de Hedy"
 msgid "hello_logo"
 msgstr "hola"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Oculto"
 

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -972,6 +972,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Tere!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Peidetud"
 

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -990,6 +990,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "چاپ"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "مخفی"
 

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "Hei!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -809,6 +809,9 @@ msgstr "Commencer le tutoriel Hedy"
 msgid "hello_logo"
 msgstr "Bonjour"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "masqués"
 

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -947,6 +947,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "hallo"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -960,6 +960,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "שלום!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "מוסתר"
 

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -888,6 +888,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "हेलो"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "संकेत?"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -950,6 +950,9 @@ msgstr "Hedy bemutató indítása"
 msgid "hello_logo"
 msgstr "Helló!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -809,6 +809,9 @@ msgstr "Ikon tutorial Hedy"
 msgid "hello_logo"
 msgstr "Halo"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Tersembunyi"
 

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -956,6 +956,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Ciao!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -984,6 +984,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "こんにちは！"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy 튜토리얼 아이콘"
 msgid "hello_logo"
 msgstr "안녕하세요"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "숨기기"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -880,6 +880,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Hallo!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Skjult"
 

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hallo"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Verborgen badges"
 

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -990,6 +990,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "چپائی"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -992,6 +992,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -799,6 +799,9 @@ msgstr "Ikona samouczka Hedy"
 msgid "hello_logo"
 msgstr "hej"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Ukryty"
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -797,6 +797,9 @@ msgstr "Ícone do tutorial da Hedy"
 msgid "hello_logo"
 msgstr "olá"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Oculto"
 

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -956,6 +956,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Ola!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "Salut!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -811,6 +811,9 @@ msgstr "Иконка учебника Hedy"
 msgid "hello_logo"
 msgstr "Привет!"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Скрытый"
 

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -957,6 +957,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "Përshëndetje!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -977,6 +977,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "zdravo"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Sakriveno"
 

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -799,6 +799,9 @@ msgstr "Logga för Hedy-handledning"
 msgid "hello_logo"
 msgstr "hej"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Gömda"
 

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -963,6 +963,9 @@ msgstr "Start hedy tutorial"
 msgid "hello_logo"
 msgstr "Hujambo!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hint?"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "Hello!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -976,6 +976,9 @@ msgstr "ไอคอนบทความเรียนรู้เกี่ย
 msgid "hello_logo"
 msgstr "สวัสดี"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "ซ่อนไว้"
 

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "dumela!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -800,6 +800,9 @@ msgstr "Hedy öğretici simgesi"
 msgid "hello_logo"
 msgstr "Merhaba"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "Gizli"
 

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -853,6 +853,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "Привіт!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -989,6 +989,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "ہیلو"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "hello"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -752,6 +752,9 @@ msgstr "Hedy 教程的图标"
 msgid "hello_logo"
 msgstr "你好"
 
+msgid "help_us_translate"
+msgstr ""
+
 msgid "hidden"
 msgstr "隐藏"
 

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -991,6 +991,9 @@ msgstr "Hedy tutorial icon"
 msgid "hello_logo"
 msgstr "你好!"
 
+msgid "help_us_translate"
+msgstr ""
+
 #, fuzzy
 msgid "hidden"
 msgstr "Hidden"


### PR DESCRIPTION
Fixes #5426 

**How to test**

1. Log out and go to languages in the menu bar. Click the "help us translate" button
2. Log in and go to my profile in the menu bar. Click the "help us translate" button

@gisellandrade @Felienne what do you think of the current designs?

<img width="1440" alt="Screenshot 2024-04-17 at 15 54 55" src="https://github.com/hedyorg/hedy/assets/48122190/959747e3-7f9c-4a7e-b543-e344e19a9c04">



I thought if that button would be orange, this one should be too, but I'm not sure if I really like the orange here:
<img width="1440" alt="Screenshot 2024-04-17 at 16 49 10" src="https://github.com/hedyorg/hedy/assets/48122190/4fce18c8-c24b-43d4-b6a5-cd91ab6a99be">

So otherwise we could change both to green?
<img width="1440" alt="Screenshot 2024-04-17 at 16 49 28" src="https://github.com/hedyorg/hedy/assets/48122190/cb3b2b6f-6df3-4328-9ec1-aa5a11d8c66a">

