### PR TITLE
📜 Use `{play}` template instead of literal `play` in music adventure

### DIFF
--- a/content/adventures/ar.yaml
+++ b/content/adventures/ar.yaml
@@ -2573,14 +2573,14 @@ adventures:
                     في المستوى التالي ستتعلم كيفية تشغيل بعض الأغاني الموجودة.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/bg.yaml
+++ b/content/adventures/bg.yaml
@@ -2726,14 +2726,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/bn.yaml
+++ b/content/adventures/bn.yaml
@@ -2652,14 +2652,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs।
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ca.yaml
+++ b/content/adventures/ca.yaml
@@ -2733,14 +2733,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/cs.yaml
+++ b/content/adventures/cs.yaml
@@ -2724,14 +2724,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/cy.yaml
+++ b/content/adventures/cy.yaml
@@ -2716,14 +2716,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/da.yaml
+++ b/content/adventures/da.yaml
@@ -2713,14 +2713,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/de.yaml
+++ b/content/adventures/de.yaml
@@ -2768,14 +2768,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/el.yaml
+++ b/content/adventures/el.yaml
@@ -2603,14 +2603,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/eo.yaml
+++ b/content/adventures/eo.yaml
@@ -2682,14 +2682,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/es.yaml
+++ b/content/adventures/es.yaml
@@ -2731,14 +2731,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/et.yaml
+++ b/content/adventures/et.yaml
@@ -2696,14 +2696,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/fa.yaml
+++ b/content/adventures/fa.yaml
@@ -2691,14 +2691,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/fi.yaml
+++ b/content/adventures/fi.yaml
@@ -2714,14 +2714,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/fy.yaml
+++ b/content/adventures/fy.yaml
@@ -2772,14 +2772,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/he.yaml
+++ b/content/adventures/he.yaml
@@ -2680,14 +2680,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/hi.yaml
+++ b/content/adventures/hi.yaml
@@ -2725,14 +2725,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs।
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/hu.yaml
+++ b/content/adventures/hu.yaml
@@ -2727,14 +2727,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ia.yaml
+++ b/content/adventures/ia.yaml
@@ -2747,14 +2747,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/id.yaml
+++ b/content/adventures/id.yaml
@@ -2695,14 +2695,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/it.yaml
+++ b/content/adventures/it.yaml
@@ -2768,14 +2768,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ja.yaml
+++ b/content/adventures/ja.yaml
@@ -2679,14 +2679,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/kmr.yaml
+++ b/content/adventures/kmr.yaml
@@ -2708,14 +2708,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ko.yaml
+++ b/content/adventures/ko.yaml
@@ -2756,14 +2756,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/mi.yaml
+++ b/content/adventures/mi.yaml
@@ -2770,14 +2770,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/nb_NO.yaml
+++ b/content/adventures/nb_NO.yaml
@@ -2679,14 +2679,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/nl.yaml
+++ b/content/adventures/nl.yaml
@@ -2711,14 +2711,14 @@ adventures:
                     In het volgende level leer je enkele bestaande nummer spelen.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/pa_PK.yaml
+++ b/content/adventures/pa_PK.yaml
@@ -2684,14 +2684,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/pap.yaml
+++ b/content/adventures/pap.yaml
@@ -2745,14 +2745,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/pl.yaml
+++ b/content/adventures/pl.yaml
@@ -2643,14 +2643,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/pt_PT.yaml
+++ b/content/adventures/pt_PT.yaml
@@ -2608,14 +2608,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ro.yaml
+++ b/content/adventures/ro.yaml
@@ -2708,14 +2708,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ru.yaml
+++ b/content/adventures/ru.yaml
@@ -2668,14 +2668,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/sq.yaml
+++ b/content/adventures/sq.yaml
@@ -2698,14 +2698,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/sr.yaml
+++ b/content/adventures/sr.yaml
@@ -2675,14 +2675,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/sv.yaml
+++ b/content/adventures/sv.yaml
@@ -2768,14 +2768,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/sw.yaml
+++ b/content/adventures/sw.yaml
@@ -2750,14 +2750,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/te.yaml
+++ b/content/adventures/te.yaml
@@ -2713,14 +2713,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/th.yaml
+++ b/content/adventures/th.yaml
@@ -2686,14 +2686,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/tl.yaml
+++ b/content/adventures/tl.yaml
@@ -2715,14 +2715,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/tn.yaml
+++ b/content/adventures/tn.yaml
@@ -2695,14 +2695,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/tr.yaml
+++ b/content/adventures/tr.yaml
@@ -2792,14 +2792,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/uk.yaml
+++ b/content/adventures/uk.yaml
@@ -2687,14 +2687,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/ur.yaml
+++ b/content/adventures/ur.yaml
@@ -2692,14 +2692,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/vi.yaml
+++ b/content/adventures/vi.yaml
@@ -2736,14 +2736,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |

--- a/content/adventures/zh_Hant.yaml
+++ b/content/adventures/zh_Hant.yaml
@@ -2715,14 +2715,14 @@ adventures:
                     In the next level you'll learn how to play some existing songs.
                 example_code: |-
                     ```
-                    play C4
-                    play D4
-                    play E4
-                    play F4
-                    play G4
-                    play A4
-                    play B4
-                    play C5
+                    {play} C4
+                    {play} D4
+                    {play} E4
+                    {play} F4
+                    {play} G4
+                    {play} A4
+                    {play} B4
+                    {play} C5
                     ```
             2:
                 story_text: |


### PR DESCRIPTION
Currently when opening the music adventure level 1 in Nederlands you'll get the following instruction:

> In dit level leer je het `speel` commando te gebruiken om een muzieknoot te spelen!

Though in the example right next to it, it says:

```
play C4
...
```

This example is English and not Nederlands. It should say:

```
speel C4
...
```

Other levels of the music adventure _do_ correctly use the `speel` command. There `{play}` template is indeed used. I applied the same template to level 1.

Let me know if I should also create an issue for this PR.

**How to test**

Follow these steps to verify this PR works as intended:

* Go to http://localhost:5000/hedy/1#music
* Change the language to "Nederlands"
* Verify that the example uses `speel` instead of `play` commands.

**Checklist**

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [ ] Links to an existing issue or discussion
- [x] Has a "How to test" section
