### PR TITLE
🚚 Fix Weblate merge conflict resolution script

### DIFF
--- a/tools/merge-weblate-resolving-conflicts.sh
+++ b/tools/merge-weblate-resolving-conflicts.sh
@@ -11,7 +11,7 @@ git checkout -B weblate-hedy-adventures-conflicts weblate-main/main
 
 # Normalize files in Weblate main repo
 doit run _autopr _autopr_weblate
-git commit -am 'Normalize Weblate branch'
+git commit -am 'Normalize Weblate branch' --allow-empty
 
 # Merge from origin, preferring Weblate's changes
 git fetch origin


### PR DESCRIPTION
The Weblate merge conflict resolution script begins with normalizing the YAML files on Weblate's branch before merging `main` (which is always normalized).

However, because we left out `--allow-empty`, it would fail if there was nothing to normalize.

Allow creating an empty commit if there's nothing to normalize, the empty commit will be squashed away anyway.
