### PR TITLE
🚚 Prevent Weblate conflicts by locking/unlocking

### DIFF
--- a/.github/workflows/resolve-weblate-conflict.yml
+++ b/.github/workflows/resolve-weblate-conflict.yml
@@ -94,3 +94,15 @@ jobs:
         branch: automatic/weblate-conflicts
         delete-branch: true
         base: main
+
+    # After we've created the PR, lock weblate and tell it to forget pending
+    # changes. The changes are now in the PR which will be merged in due time, and
+    # Weblate will be unlocked when the PR is merged.
+    - name: Prevent updates and merge conflicts until merged
+      run: |
+        wlc lock
+        # On our repo, 'wlc reset' consistently times out the TCP connection after waiting
+        # for 5 minutes. The actual reset does seem to work, so we just don't wait for the
+        # command to finish, otherwise all our workflow executions show errors.
+        wlc reset &
+        sleep 10

--- a/.github/workflows/unlock-weblate.yml
+++ b/.github/workflows/unlock-weblate.yml
@@ -1,0 +1,33 @@
+# Weblate is locked when a daily translations PR is created. Unlock Weblate
+# when that PR gets closed (either as merged or rejected).
+#
+# We do this to avoid conflicts.
+name: Unlock Weblate when PR is closed
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if:
+        github.event.pull_request.user.login == 'weblate' ||
+        contains(github.event.pull_request.labels.*.name, 'translations')
+    runs-on: ubuntu-latest
+    steps:
+    # These are all the same as in 'update-weblate.yml'
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.12
+    - name: Install Weblate Client
+      run: pip install wlc
+    - name: Prepare client config
+      run: |
+        echo '[weblate]' >> .weblate
+        echo 'url = https://hosted.weblate.org/api/' >> .weblate
+        echo 'translation = hedy' >> .weblate
+        echo '[keys]' >> .weblate
+        echo 'https://hosted.weblate.org/api/ = ${{ secrets.WEBLATE_API_KEY }}' >> .weblate
+    - run: |
+        wlc unlock

--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -45,9 +45,20 @@ jobs:
       # commits that Weblate pushes, and if the bytes aren't exactly equivalent (for example
       # if we wrap or we revert a broken bit of code) it will trigger a merge
       # conflict.
+      #
+      # To prevent merge conflicts, lock the repository while we're merging this; otherwise,
+      # any translations in the merge window will cause merge conflicts. Only lock if we're
+      # going to create a Pull Request while doing this, since unlocking will
+      # only happen as the result of a PR being merged.
       run: |
         set -x
-        wlc repo
+        wlc repo | tee repo.txt
+        if grep -q "needs_commit: False" repo.txt && grep -q "needs_push: False" repo.txt; then
+          echo "Nothing to do"
+          exit 0
+        fi
+
+        wlc lock
         wlc pull
         wlc commit
         wlc push


### PR DESCRIPTION
We're still sometimes seeing merge conflicts in Weblate because people are submitting translations in the ~1-2hr window it takes us to merge the update PR.

To completely avoid these, we're going to take rough measures: lock the Weblate repo when we start the merge process, and only unlock it after the PR is merged.

Because merging a PR is an asynchronous process, this lock/unlock behavior is split over 2 different workflows (`update-weblate.yml` to lock, `unlock-weblate.yml` to unlock).

For the cases where there are still conflicts due to manual editing in translated YAMLs, we do the same for the "Resolve conflicts" script: make it work the same as the regular daily update script (lock + make Weblate forget about changes it had that are now in a normalized PR).

**How to test**

As always, GitHub Actions workflows are hard to test. I propose we merge this and fix any problems that occur as we discover them.