### PR TITLE
💻 Option to hide explore page in customize class

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ from website import (ab_proxying, achievements, admin, auth_pages, aws_helpers,
                      cdn, classes, database, for_teachers, s3_logger, parsons,
                      profile, programs, querylog, quiz, statistics,
                      translating, tags, surveys, public_adventures, user_activity, feedback)
-from website.auth import (current_user, is_admin, is_teacher, is_second_teacher, has_public_profile,
+from website.auth import (current_user, hide_explore, is_admin, is_teacher, is_second_teacher, has_public_profile,
                           login_user_from_token_cookie, requires_login, requires_login_redirect, requires_teacher,
                           forget_current_user)
 from website.log_fetcher import log_fetcher
@@ -435,7 +435,8 @@ def enrich_context_with_user_info():
     user = current_user()
     data = {'username': user.get('username', ''),
             'is_teacher': is_teacher(user), 'is_second_teacher': is_second_teacher(user),
-            'is_admin': is_admin(user), 'has_public_profile': has_public_profile(user)}
+            'is_admin': is_admin(user), 'has_public_profile': has_public_profile(user),
+            'hide_explore': hide_explore(g.user)}
     return data
 
 

--- a/messages.pot
+++ b/messages.pot
@@ -527,6 +527,9 @@ msgstr ""
 msgid "disable"
 msgstr ""
 
+msgid "disable_explore_page"
+msgstr ""
+
 msgid "disable_parsons"
 msgstr ""
 

--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -107,6 +107,13 @@
                                         if "hide_parsons" in customizations['other_settings'] %}checked{% endif %}>
                                 </td>
                             </tr>
+                            <tr>
+                                <td class="text-left border-t border-r border-gray-400">{{_('disable_explore_page')}}</td>
+                                <td class="border-t border-gray-400">
+                                    <input class="other_settings_checkbox" id="hide_explore" type="checkbox" {%
+                                        if "hide_explore" in customizations['other_settings'] %}checked{% endif %}>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/templates/incl/menubar.html
+++ b/templates/incl/menubar.html
@@ -4,7 +4,9 @@
         <li class="ltr:mr-2 rtl:ml-2"><a href="/" class="inline-block w-10 lg:w-12"><img src="{{static('/images/Hedy-logo-96x96-round.png')}}" height="48px" width="48px" alt="{{_('hedy_logo_alt')}}"></a></li>
         <li class="flex-initial menubar-item{% if current_page == 'start' %} active{% endif %}"><a class="menubar-text" href="/" title="{{_('nav_start')}}">{{_('nav_start')}}</a></li>
         <li class="flex-initial menubar-item{% if current_page == 'hedy' %} active{% endif %}"><a class="menubar-text" id="hedybutton" href="/hedy" title="{{_('nav_hedy')}}">{{_('nav_hedy')}}</a></li>
-        <li class="flex-initial truncate menubar-item{% if current_page == 'explore' %} active{% endif %}"><a class="menubar-text" id="explorebutton" href="/explore" title="{{_('nav_explore')}}">{{_('nav_explore')}}</a></li>
+        {% if not 'hide_explore' in customizations['other_settings'] %}
+            <li class="flex-initial truncate menubar-item{% if current_page == 'explore' %} active{% endif %}"><a class="menubar-text" id="explorebutton" href="/explore" title="{{_('nav_explore')}}">{{_('nav_explore')}}</a></li>
+        {% endif %}
         {% if is_teacher  or is_second_teacher %}
             <li class="flex-initial truncate menubar-item{% if current_page == 'for-teachers' %} active{% endif %}"><a class="menubar-text" href="/for-teachers" title="{{_('for_teachers')}}">{{_('for_teachers')}}</a></li>
             <li class="flex-initial truncate menubar-item{% if current_page == 'teacher-manual' %} active{% endif %}"><a class="menubar-text" href="/for-teachers/manual" title="{{_('teacher_manual')}}">{{_('teacher_manual')}}</a></li>

--- a/templates/incl/menubar.html
+++ b/templates/incl/menubar.html
@@ -4,7 +4,7 @@
         <li class="ltr:mr-2 rtl:ml-2"><a href="/" class="inline-block w-10 lg:w-12"><img src="{{static('/images/Hedy-logo-96x96-round.png')}}" height="48px" width="48px" alt="{{_('hedy_logo_alt')}}"></a></li>
         <li class="flex-initial menubar-item{% if current_page == 'start' %} active{% endif %}"><a class="menubar-text" href="/" title="{{_('nav_start')}}">{{_('nav_start')}}</a></li>
         <li class="flex-initial menubar-item{% if current_page == 'hedy' %} active{% endif %}"><a class="menubar-text" id="hedybutton" href="/hedy" title="{{_('nav_hedy')}}">{{_('nav_hedy')}}</a></li>
-        {% if not 'hide_explore' in customizations['other_settings'] %}
+        {% if not hide_explore %}
             <li class="flex-initial truncate menubar-item{% if current_page == 'explore' %} active{% endif %}"><a class="menubar-text" id="explorebutton" href="/explore" title="{{_('nav_explore')}}">{{_('nav_explore')}}</a></li>
         {% endif %}
         {% if is_teacher  or is_second_teacher %}

--- a/tests/cypress/e2e/for-teacher_page/customize_class_page/quiz_parsons.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/customize_class_page/quiz_parsons.cy.js
@@ -1,4 +1,4 @@
-import { loginForTeacher } from '../../tools/login/login.js'
+import { loginForStudent, loginForTeacher } from '../../tools/login/login.js'
 import { ensureClass } from "../../tools/classes/class";
 
 describe('customize class page', () => {
@@ -95,7 +95,7 @@ describe('customize class page', () => {
         .should('have.value', 'quiz')
     });
 
-    it.only('disblae all quizes', () => {
+    it.only('disable all quizes', () => {
       cy.intercept('/for-teachers/customize-class/*').as('updateCustomizations');      
 
       cy.get("#hide_quiz")
@@ -114,7 +114,7 @@ describe('customize class page', () => {
         .should("not.exist")
     });
 
-    it('disblae all parsons', () => {
+    it('disable all parsons', () => {
       cy.intercept('/for-teachers/customize-class/*').as('updateCustomizations');      
 
       cy.get("#hide_parsons")
@@ -131,5 +131,21 @@ describe('customize class page', () => {
 
       cy.get('[data-cy="level-1"] [data-cy="parsons"]')
         .should("not.exist")
+    });
+
+    it('hide explore page', () => {
+      cy.intercept('/for-teachers/customize-class/*').as('updateCustomizations');      
+
+      cy.get("#hide_explore")
+          .should("not.be.checked")
+          .click()
+
+      cy.get("#hide_explore")
+          .should("be.checked")
+
+      cy.wait(1000)
+      cy.wait('@updateCustomizations').should('have.nested.property', 'response.statusCode', 200);
+      loginForStudent();
+      cy.get("#explorebutton").should("not.exist")
     });
 });

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -606,6 +606,9 @@ msgstr "افتتح مباشرة"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 msgid "disable_parsons"
 msgstr "عطل كل الأحجيات"
 

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -674,6 +674,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -697,6 +697,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -566,6 +566,9 @@ msgstr "Obrir directament"
 msgid "disable"
 msgstr "Desactiva"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -676,6 +676,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -698,6 +698,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -697,6 +697,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -566,6 +566,9 @@ msgstr "Direkt öffnen"
 msgid "disable"
 msgstr "Deaktivieren"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -623,6 +623,9 @@ msgstr "Άμεσα ανοιχτό"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -528,6 +528,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr "Disable explore page"
+
 msgid "disable_parsons"
 msgstr "Disable all puzzles"
 

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -627,6 +627,9 @@ msgstr "Rekte malfermi"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -531,6 +531,9 @@ msgstr "Directamente abierto"
 msgid "disable"
 msgstr "Deshabilitado"
 
+msgid "disable_explore_page"
+msgstr ""
+
 msgid "disable_parsons"
 msgstr "Desactivar todos los rompecabezas"
 

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -684,6 +684,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -697,6 +697,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -697,6 +697,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -575,6 +575,9 @@ msgstr "Ouvrir immédiatement"
 msgid "disable"
 msgstr "Désactiver"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -665,6 +665,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -672,6 +672,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -622,6 +622,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -667,6 +667,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -577,6 +577,9 @@ msgstr "Terbuka langsung"
 msgid "disable"
 msgstr "Nonaktif"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -672,6 +672,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -689,6 +689,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "직접 열림"
 msgid "disable"
 msgstr "사용 안 함"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -615,6 +615,9 @@ msgstr "Åpne på direkten"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -545,6 +545,9 @@ msgstr "Gelijk open"
 msgid "disable"
 msgstr "Deactiveren"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -566,6 +566,9 @@ msgstr "Zawsze dostępne"
 msgid "disable"
 msgstr "Wyłącz"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -560,6 +560,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Desativar"
 
+msgid "disable_explore_page"
+msgstr ""
+
 msgid "disable_parsons"
 msgstr "Desativar todos os desafios"
 

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -672,6 +672,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -697,6 +697,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -576,6 +576,9 @@ msgstr "Прямое открытие"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -669,6 +669,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -688,6 +688,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -566,6 +566,9 @@ msgstr "Öppna direkt"
 msgid "disable"
 msgstr "Inaktivera"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -678,6 +678,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -568,6 +568,9 @@ msgstr "Doğrudan açın"
 msgid "disable"
 msgstr "Devre dışı bırak"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -579,6 +579,9 @@ msgstr "Безпосередньо відкрити"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -694,6 +694,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -531,6 +531,9 @@ msgstr "直接打开"
 msgid "disable"
 msgstr "禁用"
 
+msgid "disable_explore_page"
+msgstr ""
+
 msgid "disable_parsons"
 msgstr "禁用所有拼图"
 

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -696,6 +696,9 @@ msgstr "Directly open"
 msgid "disable"
 msgstr "Disable"
 
+msgid "disable_explore_page"
+msgstr ""
+
 #, fuzzy
 msgid "disable_parsons"
 msgstr "Disable all puzzles"

--- a/website/auth.py
+++ b/website/auth.py
@@ -196,6 +196,14 @@ def has_public_profile(user):
 
 # Thanks to https://stackoverflow.com/a/34499643
 
+def hide_explore(user):
+    if 'username' not in user or user.get('username') == '':
+        return False
+    username = user.get('username')
+    customizations = g.db.get_student_class_customizations(username)
+    hide_explore = True if customizations and 'hide_explore' in customizations.get('other_settings') else False
+    return hide_explore
+
 
 def requires_login(f):
     """Decoractor to indicate that a particular route requires the user to be logged in.


### PR DESCRIPTION
Fixes #5427 

**How to test**
1. Log in as a teacher
2. Go to `for-teachers`
3. Go to customize class of a class with students
4. Select 'Disable explore page'
5. Log in as a student of that class
6. See if the Explore page is hidden


<img width="1406" alt="Screenshot 2024-04-22 at 16 24 58" src="https://github.com/hedyorg/hedy/assets/48122190/cb41d6f2-95a2-46bf-99df-7f34195bac35">
