### PR TITLE
🚚 Resolve Weblate conflicts script doesn't lock properly

### DIFF
--- a/.github/workflows/resolve-weblate-conflict.yml
+++ b/.github/workflows/resolve-weblate-conflict.yml
@@ -110,7 +110,11 @@ jobs:
     # Weblate will be unlocked when the PR is merged.
     - name: Prevent updates and merge conflicts until merged
       run: |
-        wlc lock
+        # Have to lock each component individually. Not in the UI, but using the CLI we do.
+        for component in glossary adventures keywords achievements quizzes commands client-messages web-texts webpages parsons tutorials slides; do
+          wlc lock hedy/$component
+        done
+
         # On our repo, 'wlc reset' consistently times out the TCP connection after waiting
         # for 5 minutes. The actual reset does seem to work, so we just don't wait for the
         # command to finish, otherwise all our workflow executions show errors.


### PR DESCRIPTION
The "lock" command was correct for the daily Weblate job, but I forgot to update it for the on-demand "resolve conflicts" job.
