### PR TITLE
🪲 correctly remove adventure from adventrues table

### DIFF
--- a/templates/htmx-adventures-table.html
+++ b/templates/htmx-adventures-table.html
@@ -43,7 +43,8 @@
                   hx-confirm="{{_('delete_adventure_prompt')}}"
                   hx-trigger="click"
                   hx-delete="/for-teachers/customize-adventure/{{adventure.id}}"
-                  hx-target="#adventures_table">
+                  hx-target="#adventures_table"
+                  hx-swap="outerHTML">
                     <span class="fas fa-trash block mb-1 text-red-700"></span>
                     <span class="text-red-700">{{_('remove')}}</span>
                   </button>

--- a/tests/cypress/e2e/tools/adventures/adventure.js
+++ b/tests/cypress/e2e/tools/adventures/adventure.js
@@ -35,6 +35,8 @@ export function deleteAdventure(name) {
         }
     })
     cy.get('[data-cy="modal_yes_button"]').should('be.enabled').click();
+    cy.get("#adventures_table")
+        .should("be.visible");
 }
 
 export default {createAdventure};


### PR DESCRIPTION
Related to https://github.com/hedyorg/hedy/issues/5383

Removing an adventure from the adventures table isn't working correctly (check alpha/beta)

**How to test?**
- go to for-teachers
- remove an adventure,
- the table should still be visible and the adventure removed