### PR TITLE
🪲 Fix color command error

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -2039,7 +2039,9 @@ class ConvertToPython_4(ConvertToPython_3):
             if self.is_quoted(name):
                 name = name[1:-1]
                 return name.replace("'", "\\'")
-            name = name if self.is_bool(name) else escape_var(name.replace("'", "\\'"))
+            if not ConvertToPython.is_int(name) and not ConvertToPython.is_float(name):
+                name = name if self.is_bool(name) else escape_var(name.replace("'", "\\'"))
+                name = '"' + name + '"'
             return f'{{convert_numerals("{self.numerals_language}", {name})}}'
 
     def var_access(self, meta, args):

--- a/tests/test_level/test_level_04.py
+++ b/tests/test_level/test_level_04.py
@@ -1044,7 +1044,7 @@ class TestsLevel4(HedyTester):
     @parameterized.expand(hedy.english_colors)
     def test_all_colors(self, color):
         code = f'color {color}'
-        expected = HedyTester.turtle_color_command_transpiled(f'{{convert_numerals("Latin", {color})}}')
+        expected = HedyTester.turtle_color_command_transpiled(f'{{convert_numerals("Latin", "{color}")}}')
 
         self.multi_level_tester(
             code=code,
@@ -1054,7 +1054,7 @@ class TestsLevel4(HedyTester):
 
     def test_color_red(self):
         code = "color red"
-        expected = HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", red)}')
+        expected = HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", "red")}')
 
         self.multi_level_tester(
             code=code,
@@ -1066,7 +1066,7 @@ class TestsLevel4(HedyTester):
     def test_color_translated(self):
         lang = 'nl'
         code = "kleur blauw"
-        expected = HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", blue)}', lang)
+        expected = HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", "blue")}', lang)
 
         self.multi_level_tester(
             code=code,
@@ -1082,7 +1082,7 @@ class TestsLevel4(HedyTester):
         forward 10""")
 
         expected = HedyTester.dedent(
-            HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", red)}', 'en'),
+            HedyTester.turtle_color_command_transpiled('{convert_numerals("Latin", "red")}', 'en'),
             HedyTester.forward_transpiled('10', self.level))
 
         self.multi_level_tester(

--- a/tests/test_level/test_level_15.py
+++ b/tests/test_level/test_level_15.py
@@ -36,9 +36,9 @@ class TestsLevel15(HedyTester):
         )
 
     @parameterized.expand(HedyTester.booleans)
-    def test_print_boolean(self, value, expected):
+    def test_print_boolean(self, value, exp):
         code = f"print 'variable is ' {value}"
-        expected = f"print(f'''variable is {{convert_numerals(\"Latin\", {expected})}}''')"
+        expected = f"print(f'''variable is {{convert_numerals(\"Latin\", \"{exp}\")}}''')"
 
         self.multi_level_tester(
             code=code,
@@ -50,7 +50,7 @@ class TestsLevel15(HedyTester):
     @parameterized.expand([('вярно', True), ('Вярно', True), ('невярно', False), ('Невярно', False)])
     def test_print_boolean_bulgarian(self, value, exp):
         code = f"принтирай 'Това е ' {value}"
-        expected = f"print(f'''Това е {{convert_numerals(\"Latin\", {exp})}}''')"
+        expected = f"print(f'''Това е {{convert_numerals(\"Latin\", \"{exp}\")}}''')"
 
         self.multi_level_tester(
             code=code,

--- a/tests/test_level/test_level_17.py
+++ b/tests/test_level/test_level_17.py
@@ -548,7 +548,7 @@ class TestsLevel17(HedyTester):
         if_pressed_mapping = {{"else": "if_pressed_default_else"}}
         if_pressed_mapping['x'] = 'if_pressed_x_'
         def if_pressed_x_():
-            __trtl = f'{{convert_numerals("Latin", red)}}'
+            __trtl = f'{{convert_numerals("Latin", "red")}}'
             color_dict = {color_dict}
             if __trtl not in ['black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'white', 'yellow']:
               raise Exception(f{self.value_exception_transpiled()})


### PR DESCRIPTION
Fixes #5597
The color command fails with an unknown variable error because colors are not transpiled to literal colors but to variables.

**How to test**
- In level 4, the following command `color red` should work and make the turtle red. There should be no errors.