### PR TITLE
🪲 Increase timeout for if_pressed programs #5678

### DIFF
--- a/static/js/app.ts
+++ b/static/js/app.ts
@@ -1073,8 +1073,8 @@ export function runPythonProgram(this: any, code: string, sourceMap: any, hasTur
       // So: a very large limit in these levels, keep the limit on other ones.
       execLimit: (function () {
         const level = theLevel;
-        if (hasTurtle || hasMusic) {
-          // We don't want a timeout when using the turtle or music -> just set one for 10 minutes
+        if (hasTurtle || hasPressed || hasMusic) {
+          // We don't want a timeout when using the turtle, if_pressed or music -> just set one for 10 minutes
           return (6000000);
         }
         if (level < 7) {


### PR DESCRIPTION
Fixes #5678
Increased the timeout of if_pressed programs from 10 seconds to 10 minutes. The random failures turned out to be timeouts. While cleaning up the pygame code, I think we accidentally reduced the timeout for if_pressed programs. This surfaced as random failures especially when there are multiple if_pressed executions, e.g. in a `repeat` command.

**How to test**
Go to level 7 and run the following program:
```
repeat 3 times if x is pressed print 'x' else print 'another'
```
Wait for 10 seconds and then press a button. The program should not stop and there should be no errors reports in the network tab of the browser.