### PR TITLE
🧹 Add extra logging when unlocking Weblate

### DIFF
--- a/.github/workflows/unlock-weblate.yml
+++ b/.github/workflows/unlock-weblate.yml
@@ -31,6 +31,8 @@ jobs:
         echo 'https://hosted.weblate.org/api/ = ${{ secrets.WEBLATE_API_KEY }}' >> .weblate
     - run: |
         # Have to lock each component individually. Not in the UI, but using the CLI we do.
+        set -x
         for component in glossary adventures keywords quizzes commands client-messages web-texts webpages parsons tutorials slides; do
-          wlc unlock hedy/$component
+          wlc --debug unlock hedy/$component | sed 's/${{ secrets.WEBLATE_API_KEY }}/*****/g'
         done
+        echo "All components unlocked!"


### PR DESCRIPTION
We have seen evidence of the `wlc unlock` command not unlocking anything. Add more debugging to see what's going on, so that we can create a bug report to Weblate.

The `wlc --debug` flag also prints out the API key, so we have to make sure to mask the API key out again so it doesn't end up in the logs.
