### PR TITLE
🚚 Add sleeps to daily Weblate Update script

### DIFF
--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -64,11 +64,25 @@ jobs:
         done
 
         wlc pull
+
+        # 'commit' seems to be an async process, as sometimes nothing is pushed if we run this
+        # too quickly in succession. Add a short sleep to reduce chances of this happening.
+        # https://github.com/WeblateOrg/weblate/issues/12400
         wlc commit
+        sleep 10
+
         wlc push
-        # On our repo, 'wlc reset' consistently times out the TCP connection after waiting
-        # for 5 minutes. The actual reset does seem to work, so we just don't wait for the
-        # command to finish, otherwise all our workflow executions show errors.
+        sleep 10
+
+        # Safety check: we should now see `needs_commit: False` and `needs_push: False`. If we don't,
+        # the 'wlc reset` below is going to lead to data loss.
+        if grep -q "needs_commit: True" repo.txt || grep -q "needs_push: True" repo.txt; then
+          echo "wlc commit and push combo didn't flush out all changes; aborting before we lose data!"
+          exit 1
+        fi
+
+        # 'wlc reset' always leads to ConnectionAborted, so don't wait for it.
+        # https://github.com/WeblateOrg/weblate/issues/11368
         wlc reset &
         sleep 10
 


### PR DESCRIPTION
It seems that `wlc commit` followed by `wlc push` doesn't always create a PR (WeblateOrg/weblate#12400). This is the cause of the Weblate repository sometimes being locked without ever getting unlocked: unlocking happens on the PR-close workflow, but the PR never gets created.

In fact, since we also run a `wlc reset` to avoid future merge conflicts, the `wlc reset` destroys all pending translator changes, which has happened to some contributors and now their work is gone.

Add some sleeps to get a (presumably) async commit process to finish, and do an additional check for the `push` flag to reduce chances of data loss.

**How to test**

This is hard to test in isolation. We'll just have to monitor the GitHub Workflow runs over the next couple of days.