### PR TITLE
🚚 Add queue name to `pull_request_rules`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,4 +20,5 @@ pull_request_rules:
     actions:
       comment:
         message: Thank you for contributing! Your pull request is now going on the merge train (choo choo! Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
-
+      queue:
+        name: default_queue


### PR DESCRIPTION
The mergify script is not working properly and we might think it can be related to this:

> Oops! In hindsight, I think we shouldn't have removed this part:
> ```
> queue:
>   name: default_queue
> ```
> That's probably the command to enqueue the PR for actual merging.
> 
> Noticing this after noticing that the Weblate PR didn't merge itself.

Original comment made by Rico in: https://github.com/hedyorg/hedy/pull/5738/files#r1742077765


