### PR TITLE
🚚 Include files in template directory in tailwind task

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -103,6 +103,7 @@ def task_tailwind():
     return dict(
         file_dep=[
             *glob('templates/**/*.html'),
+            *glob('templates/*.html'),
             *glob('main/**/*.md'),
             *glob('content/**/*.md'),
             # exclude files generated for translations


### PR DESCRIPTION
I noticed that when I added new tailwind classes in HTML files in the `templates` directory, the dodo task didn't compile them, and therefore didn't work. When I added the classes in files inside subfolders, the task was completed succesfully. Therefore in this PR I'm including a new glob pattern for files directly inside the  `templates` directory.