### PR TITLE
🚚 Send message to Discord when deploying to hedy.org

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -17,3 +17,7 @@ jobs:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: hedy-beta
           heroku_email: felienne@gmail.com
+      - name: "Send message on Discord"
+        uses: distributhor/workflow-webhook@v3
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -18,6 +18,10 @@ jobs:
           heroku_app_name: hedy-beta
           heroku_email: felienne@gmail.com
       - name: "Send message on Discord"
-        uses: distributhor/workflow-webhook@v3
+        if: success()
+        uses: discord-actions/message@v2
         with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+          username: "Github"
+          avatar: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          message: "Deployed to hedy.org"


### PR DESCRIPTION
Send a message to Discord once we deploy to production. 

Fixes #5742

**How to test**

* We have to accept and deploy, and then will see if this does send the message.

