### PR TITLE
🚚 Allow the deploy to alpha github action to be triggered manually

### DIFF
--- a/.github/workflows/deploy-to-alpha.yml
+++ b/.github/workflows/deploy-to-alpha.yml
@@ -1,5 +1,7 @@
 name: Automatically deploy to Alpha
 on:
+  workflow_dispatch: {}
+  
   # Run this AFTER the unit test job finishes
   workflow_run:
     # Must be the same as in unittests.yml, cypresstests.yml


### PR DESCRIPTION
Fixes #5862

**How to test**
Double-check that this is a correct syntax. After it is merged check that the action is executed automatically but could also be executed manually.
