### PR TITLE
🚚 Fix extra newlines in co-authors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,9 +9,9 @@ queue_rules:
       {{ title }} (#{{number}})
       {{ body }}
       {# Add co-author information at the end of the squash merge commit message #}
-      {% for co_author in co_authors | unique %}
+      {% for co_author in co_authors | unique -%}
       Co-Authored-By: {{ co_author.name }} <{{ co_author.email }}>
-      {% endfor %}
+      {% endfor -%}
       {# `Co-Authored-By` lines must the be last ones for GitHub to recognize them #}
 
 pull_request_rules:


### PR DESCRIPTION
Fixes a small issue with https://github.com/hedyorg/hedy/pull/5852
Jinja template adds a new line after each iteration, this makes Github only recognize the last co-author. This error can be seen here: https://github.com/hedyorg/hedy/commit/d1109b1c8bf8834682b41d95ea5b985680402aaf

Adding `-%` to the template removes this extra newlines 
