### PR TITLE
🪲 Improve error message for missing list in add-to and remove-from commands

### DIFF
--- a/grammars/keywords-ar.lark
+++ b/grammars/keywords-ar.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("هو" | "هي" | "is") _SPACE
 _STANDALONE_IS: ("هو" | "هي" | "is")
 _SLEEP: ( "ـ"* "ا" "ـ"* "ن" "ـ"* "ت" "ـ"* "ظ" "ـ"* "ر" "ـ"*  | "sleep") _SPACE?
 _ADD_LIST: ( "ـ"* "ا" "ـ"* "ض" "ـ"* "ف" "ـ"*  | "add") _SPACE
-_TO_LIST: _SPACE? ( "ـ"* "ا" "ـ"* "ل" "ـ"* "ى" "ـ"*  | "to") _SPACE
+_TO_LIST: _SPACE? ( "ـ"* "ا" "ـ"* "ل" "ـ"* "ى" "ـ"*  | "to")
 _REMOVE: ( "ـ"* "ا" "ـ"* "ز" "ـ"* "ل" "ـ"*  | "remove") _SPACE
-_FROM: _SPACE? ( "ـ"* "م" "ـ"* "ن" "ـ"*  | "from") _SPACE
+_FROM: _SPACE? ( "ـ"* "م" "ـ"* "ن" "ـ"*  | "from")
 _AT: _SPACE ( "ـ"* "ب" "ـ"* "ش" "ـ"* "ك" "ـ"* "ل" "ـ"*  | "at") _SPACE
 random: ( "ـ"* "ع" "ـ"* "ش" "ـ"* "و" "ـ"* "ا" "ـ"* "ئ" "ـ"* "ي" "ـ"*  | "random") _SPACE?
 _IN: _SPACE ( "ـ"* "ف" "ـ"* "ي" "ـ"*  | "in") _SPACE

--- a/grammars/keywords-bg.lark
+++ b/grammars/keywords-bg.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("е" | "is") _SPACE
 _STANDALONE_IS: ("е" | "is")
 _SLEEP: ("спи" | "sleep") _SPACE?
 _ADD_LIST: ("добави" | "add") _SPACE
-_TO_LIST: _SPACE? ("до" | "to") _SPACE
+_TO_LIST: _SPACE? ("до" | "to")
 _REMOVE: ("премахни" | "remove") _SPACE
-_FROM: _SPACE? ("от" | "from") _SPACE
+_FROM: _SPACE? ("от" | "from")
 _AT: _SPACE ("в" | "at") _SPACE
 random: ("произволно" | "random") _SPACE?
 _IN: _SPACE ("в" | "in") _SPACE

--- a/grammars/keywords-bn.lark
+++ b/grammars/keywords-bn.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ca.lark
+++ b/grammars/keywords-ca.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("és" | "is") _SPACE
 _STANDALONE_IS: ("és" | "is")
 _SLEEP: ("dorm" | "sleep") _SPACE?
 _ADD_LIST: ("afegeix" | "add") _SPACE
-_TO_LIST: _SPACE? ("a" | "to") _SPACE
+_TO_LIST: _SPACE? ("a" | "to")
 _REMOVE: ("esborra" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("a" | "at") _SPACE
 random: ("aleatori" | "random") _SPACE?
 _IN: _SPACE ("dins" | "in") _SPACE

--- a/grammars/keywords-cs.lark
+++ b/grammars/keywords-cs.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-cy.lark
+++ b/grammars/keywords-cy.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("yw" | "is") _SPACE
 _STANDALONE_IS: ("yw" | "is")
 _SLEEP: ("cysgu" | "sleep") _SPACE?
 _ADD_LIST: ("adio" | "add") _SPACE
-_TO_LIST: _SPACE? ("i" | "to") _SPACE
+_TO_LIST: _SPACE? ("i" | "to")
 _REMOVE: ("dileu" | "remove") _SPACE
-_FROM: _SPACE? ("o" | "from") _SPACE
+_FROM: _SPACE? ("o" | "from")
 _AT: _SPACE ("ar" | "at") _SPACE
 random: ("hap" | "random") _SPACE?
 _IN: _SPACE ("mewn" | "in") _SPACE

--- a/grammars/keywords-da.lark
+++ b/grammars/keywords-da.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("tilføj" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("ved" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-de.lark
+++ b/grammars/keywords-de.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("ist" | "is") _SPACE
 _STANDALONE_IS: ("ist" | "is")
 _SLEEP: ("schlafe" | "sleep") _SPACE?
 _ADD_LIST: ("addiere" | "add") _SPACE
-_TO_LIST: _SPACE? ("zu" | "to") _SPACE
+_TO_LIST: _SPACE? ("zu" | "to")
 _REMOVE: ("entferne" | "remove") _SPACE
-_FROM: _SPACE? ("aus" | "from") _SPACE
+_FROM: _SPACE? ("aus" | "from")
 _AT: _SPACE ("an" | "at") _SPACE
 random: ("zufällig" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-el.lark
+++ b/grammars/keywords-el.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-en.lark
+++ b/grammars/keywords-en.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-eo.lark
+++ b/grammars/keywords-eo.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("estas" | "is") _SPACE
 _STANDALONE_IS: ("estas" | "is")
 _SLEEP: ("dormu" | "sleep") _SPACE?
 _ADD_LIST: ("aldonu" | "add") _SPACE
-_TO_LIST: _SPACE? ("al" | "to") _SPACE
+_TO_LIST: _SPACE? ("al" | "to")
 _REMOVE: ("forigu" | "remove") _SPACE
-_FROM: _SPACE? ("el" | "from") _SPACE
+_FROM: _SPACE? ("el" | "from")
 _AT: _SPACE ("laŭ" | "lau" | "laux" | "at") _SPACE
 random: ("hazardo" | "random") _SPACE?
 _IN: _SPACE ("en" | "in") _SPACE

--- a/grammars/keywords-es.lark
+++ b/grammars/keywords-es.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("es" | "is") _SPACE
 _STANDALONE_IS: ("es" | "is")
 _SLEEP: ("dormir" | "sleep") _SPACE?
 _ADD_LIST: ("añadir" | "add") _SPACE
-_TO_LIST: _SPACE? ("a" | "to") _SPACE
+_TO_LIST: _SPACE? ("a" | "to")
 _REMOVE: ("borrar" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("en" | "at") _SPACE
 random: ("aleatorio" | "random") _SPACE?
 _IN: _SPACE ("en" | "in") _SPACE

--- a/grammars/keywords-et.lark
+++ b/grammars/keywords-et.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("on" | "is") _SPACE
 _STANDALONE_IS: ("on" | "is")
 _SLEEP: ("oota" | "sleep") _SPACE?
 _ADD_LIST: ("lisa" | "add") _SPACE
-_TO_LIST: _SPACE? ("nimistusse" | "to") _SPACE
+_TO_LIST: _SPACE? ("nimistusse" | "to")
 _REMOVE: ("kustuta" | "remove") _SPACE
-_FROM: _SPACE? ("nimistust" | "from") _SPACE
+_FROM: _SPACE? ("nimistust" | "from")
 _AT: _SPACE ("täitsa" | "at") _SPACE
 random: ("juhuslikult" | "random") _SPACE?
 _IN: _SPACE ("nimistus" | "in") _SPACE

--- a/grammars/keywords-fa.lark
+++ b/grammars/keywords-fa.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-fi.lark
+++ b/grammars/keywords-fi.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("on" | "is") _SPACE
 _STANDALONE_IS: ("on" | "is")
 _SLEEP: ("nuku" | "sleep") _SPACE?
 _ADD_LIST: ("lisää" | "add") _SPACE
-_TO_LIST: _SPACE? ("listaksi" | "to") _SPACE
+_TO_LIST: _SPACE? ("listaksi" | "to")
 _REMOVE: ("poista" | "remove") _SPACE
-_FROM: _SPACE? ("listasta" | "from") _SPACE
+_FROM: _SPACE? ("listasta" | "from")
 _AT: _SPACE ("ota" | "at") _SPACE
 random: ("satunnainen" | "random") _SPACE?
 _IN: _SPACE ("listassa" | "in") _SPACE

--- a/grammars/keywords-fr.lark
+++ b/grammars/keywords-fr.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("est" | "is") _SPACE
 _STANDALONE_IS: ("est" | "is")
 _SLEEP: ("dors" | "sleep") _SPACE?
 _ADD_LIST: ("ajoute" | "add") _SPACE
-_TO_LIST: _SPACE? ("à" | "to") _SPACE
+_TO_LIST: _SPACE? ("à" | "to")
 _REMOVE: ("supprime" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("au" | "at") _SPACE
 random: ("hasard" | "random") _SPACE?
 _IN: _SPACE ("dans" | "in") _SPACE

--- a/grammars/keywords-fr_CA.lark
+++ b/grammars/keywords-fr_CA.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("est" | "is") _SPACE
 _STANDALONE_IS: ("est" | "is")
 _SLEEP: ("dors" | "sleep") _SPACE?
 _ADD_LIST: ("ajoute" | "add") _SPACE
-_TO_LIST: _SPACE? ("à" | "to") _SPACE
+_TO_LIST: _SPACE? ("à" | "to")
 _REMOVE: ("supprime" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("au" | "at") _SPACE
 random: ("hasard" | "random") _SPACE?
 _IN: _SPACE ("dans" | "in") _SPACE

--- a/grammars/keywords-fy.lark
+++ b/grammars/keywords-fy.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-he.lark
+++ b/grammars/keywords-he.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("הוא" | "is") _SPACE
 _STANDALONE_IS: ("הוא" | "is")
 _SLEEP: ("המתן" | "sleep") _SPACE?
 _ADD_LIST: ("הוסף" | "add") _SPACE
-_TO_LIST: _SPACE? ("אל" | "to") _SPACE
+_TO_LIST: _SPACE? ("אל" | "to")
 _REMOVE: ("הסר" | "remove") _SPACE
-_FROM: _SPACE? ("מ" | "from") _SPACE
+_FROM: _SPACE? ("מ" | "from")
 _AT: _SPACE ("ב" | "at") _SPACE
 random: ("אקראי" | "random") _SPACE?
 _IN: _SPACE ("בתוך" | "in") _SPACE

--- a/grammars/keywords-hi.lark
+++ b/grammars/keywords-hi.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("है" | "is") _SPACE
 _STANDALONE_IS: ("है" | "is")
 _SLEEP: ("नींद" | "sleep") _SPACE?
 _ADD_LIST: ("जोड़ना" | "add") _SPACE
-_TO_LIST: _SPACE? ("से" | "to") _SPACE
+_TO_LIST: _SPACE? ("से" | "to")
 _REMOVE: ("हटाना" | "remove") _SPACE
-_FROM: _SPACE? ("से" | "from") _SPACE
+_FROM: _SPACE? ("से" | "from")
 _AT: _SPACE ("पर" | "at") _SPACE
 random: ("अनियमित" | "random") _SPACE?
 _IN: _SPACE ("में" | "in") _SPACE

--- a/grammars/keywords-hr.lark
+++ b/grammars/keywords-hr.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-hu.lark
+++ b/grammars/keywords-hu.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("egyenlő" | "is") _SPACE
 _STANDALONE_IS: ("egyenlő" | "is")
 _SLEEP: ("szundi" | "sleep") _SPACE?
 _ADD_LIST: ("beszúr" | "add") _SPACE
-_TO_LIST: _SPACE? ("ebbe" | "to") _SPACE
+_TO_LIST: _SPACE? ("ebbe" | "to")
 _REMOVE: ("kivesz" | "remove") _SPACE
-_FROM: _SPACE? ("ebből" | "from") _SPACE
+_FROM: _SPACE? ("ebből" | "from")
 _AT: _SPACE ("listából" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("eleme" | "in") _SPACE

--- a/grammars/keywords-ia.lark
+++ b/grammars/keywords-ia.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("es" | "is") _SPACE
 _STANDALONE_IS: ("es" | "is")
 _SLEEP: ("dormir" | "sleep") _SPACE?
 _ADD_LIST: ("adde" | "add") _SPACE
-_TO_LIST: _SPACE? ("a" | "to") _SPACE
+_TO_LIST: _SPACE? ("a" | "to")
 _REMOVE: ("removere" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("a" | "at") _SPACE
 random: ("aleatori" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-iba.lark
+++ b/grammars/keywords-iba.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-id.lark
+++ b/grammars/keywords-id.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("adalah" | "is") _SPACE
 _STANDALONE_IS: ("adalah" | "is")
 _SLEEP: ("tidur" | "sleep") _SPACE?
 _ADD_LIST: ("tambah" | "add") _SPACE
-_TO_LIST: _SPACE? ("ke" | "to") _SPACE
+_TO_LIST: _SPACE? ("ke" | "to")
 _REMOVE: ("hapus" | "remove") _SPACE
-_FROM: _SPACE? ("dari" | "from") _SPACE
+_FROM: _SPACE? ("dari" | "from")
 _AT: _SPACE ("secara" | "at") _SPACE
 random: ("acak" | "random") _SPACE?
 _IN: _SPACE ("dalam" | "in") _SPACE

--- a/grammars/keywords-it.lark
+++ b/grammars/keywords-it.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("dormi" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("rimuovi" | "remove") _SPACE
-_FROM: _SPACE? ("da" | "from") _SPACE
+_FROM: _SPACE? ("da" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("a caso" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ja.lark
+++ b/grammars/keywords-ja.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("やすめ" | "sleep") _SPACE?
 _ADD_LIST: ("たす" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-kmr.lark
+++ b/grammars/keywords-kmr.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ko.lark
+++ b/grammars/keywords-ko.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-mi.lark
+++ b/grammars/keywords-mi.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ms.lark
+++ b/grammars/keywords-ms.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("tambah" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-nb_NO.lark
+++ b/grammars/keywords-nb_NO.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("er" | "is") _SPACE
 _STANDALONE_IS: ("er" | "is")
 _SLEEP: ("sov" | "sleep") _SPACE?
 _ADD_LIST: ("legg" | "add") _SPACE
-_TO_LIST: _SPACE? ("til" | "to") _SPACE
+_TO_LIST: _SPACE? ("til" | "to")
 _REMOVE: ("fjern" | "remove") _SPACE
-_FROM: _SPACE? ("fra" | "from") _SPACE
+_FROM: _SPACE? ("fra" | "from")
 _AT: _SPACE ("på" | "at") _SPACE
 random: ("tilfeldig" | "random") _SPACE?
 _IN: _SPACE ("i" | "in") _SPACE

--- a/grammars/keywords-ne.lark
+++ b/grammars/keywords-ne.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-nl.lark
+++ b/grammars/keywords-nl.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("slaap" | "sleep") _SPACE?
 _ADD_LIST: ("voeg" | "add") _SPACE
-_TO_LIST: _SPACE? ("toe aan" | "to") _SPACE
+_TO_LIST: _SPACE? ("toe aan" | "to")
 _REMOVE: ("verwijder" | "remove") _SPACE
-_FROM: _SPACE? ("uit" | "from") _SPACE
+_FROM: _SPACE? ("uit" | "from")
 _AT: _SPACE ("op" | "at") _SPACE
 random: ("willekeurig" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-pa_PK.lark
+++ b/grammars/keywords-pa_PK.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("سمان" | "is") _SPACE
 _STANDALONE_IS: ("سمان" | "is")
 _SLEEP: ("نیند" | "sleep") _SPACE?
 _ADD_LIST: ("دھن" | "add") _SPACE
-_TO_LIST: _SPACE? ("منزل" | "to") _SPACE
+_TO_LIST: _SPACE? ("منزل" | "to")
 _REMOVE: ("مٹاکے" | "remove") _SPACE
-_FROM: _SPACE? ("سروت" | "from") _SPACE
+_FROM: _SPACE? ("سروت" | "from")
 _AT: _SPACE ("ستھتی" | "at") _SPACE
 random: ("رلوان" | "random") _SPACE?
 _IN: _SPACE ("اندر" | "in") _SPACE

--- a/grammars/keywords-pap.lark
+++ b/grammars/keywords-pap.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-peo.lark
+++ b/grammars/keywords-peo.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-pl.lark
+++ b/grammars/keywords-pl.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("to" | "is") _SPACE
 _STANDALONE_IS: ("to" | "is")
 _SLEEP: ("śpij" | "sleep") _SPACE?
 _ADD_LIST: ("dodaj" | "add") _SPACE
-_TO_LIST: _SPACE? ("do" | "to") _SPACE
+_TO_LIST: _SPACE? ("do" | "to")
 _REMOVE: ("usuń" | "remove") _SPACE
-_FROM: _SPACE? ("z" | "from") _SPACE
+_FROM: _SPACE? ("z" | "from")
 _AT: _SPACE ("pozycja" | "at") _SPACE
 random: ("losowa" | "random") _SPACE?
 _IN: _SPACE ("w" | "in") _SPACE

--- a/grammars/keywords-pt_BR.lark
+++ b/grammars/keywords-pt_BR.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("é" | "is") _SPACE
 _STANDALONE_IS: ("é" | "is")
 _SLEEP: ("durma" | "sleep") _SPACE?
 _ADD_LIST: ("some" | "add") _SPACE
-_TO_LIST: _SPACE? ("a" | "to") _SPACE
+_TO_LIST: _SPACE? ("a" | "to")
 _REMOVE: ("remova" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("'em'" | "at") _SPACE
 random: ("aleatório" | "random") _SPACE?
 _IN: _SPACE ("em" | "in") _SPACE

--- a/grammars/keywords-pt_PT.lark
+++ b/grammars/keywords-pt_PT.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("é" | "is") _SPACE
 _STANDALONE_IS: ("é" | "is")
 _SLEEP: ("dormir" | "sleep") _SPACE?
 _ADD_LIST: ("adicionar" | "add") _SPACE
-_TO_LIST: _SPACE? ("para" | "to") _SPACE
+_TO_LIST: _SPACE? ("para" | "to")
 _REMOVE: ("remover" | "remove") _SPACE
-_FROM: _SPACE? ("de" | "from") _SPACE
+_FROM: _SPACE? ("de" | "from")
 _AT: _SPACE ("'no'" | "at") _SPACE
 random: ("aleatório" | "random") _SPACE?
 _IN: _SPACE ("em" | "in") _SPACE

--- a/grammars/keywords-ro.lark
+++ b/grammars/keywords-ro.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("adună" | "add") _SPACE
-_TO_LIST: _SPACE? ("către" | "to") _SPACE
+_TO_LIST: _SPACE? ("către" | "to")
 _REMOVE: ("elimină" | "remove") _SPACE
-_FROM: _SPACE? ("de la" | "from") _SPACE
+_FROM: _SPACE? ("de la" | "from")
 _AT: _SPACE ("la" | "at") _SPACE
 random: ("aleatoriu" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ru.lark
+++ b/grammars/keywords-ru.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("это" | "is") _SPACE
 _STANDALONE_IS: ("это" | "is")
 _SLEEP: ("заснуть" | "sleep") _SPACE?
 _ADD_LIST: ("добавить" | "add") _SPACE
-_TO_LIST: _SPACE? ("в" | "to") _SPACE
+_TO_LIST: _SPACE? ("в" | "to")
 _REMOVE: ("удалить" | "remove") _SPACE
-_FROM: _SPACE? ("из" | "from") _SPACE
+_FROM: _SPACE? ("из" | "from")
 _AT: _SPACE ("в" | "at") _SPACE
 random: ("случайном" | "random") _SPACE?
 _IN: _SPACE ("в" | "in") _SPACE

--- a/grammars/keywords-sl.lark
+++ b/grammars/keywords-sl.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("je" | "is") _SPACE
 _STANDALONE_IS: ("je" | "is")
 _SLEEP: ("zaspi" | "sleep") _SPACE?
 _ADD_LIST: ("dodaj" | "add") _SPACE
-_TO_LIST: _SPACE? ("do" | "to") _SPACE
+_TO_LIST: _SPACE? ("do" | "to")
 _REMOVE: ("odstrani" | "remove") _SPACE
-_FROM: _SPACE? ("od" | "from") _SPACE
+_FROM: _SPACE? ("od" | "from")
 _AT: _SPACE ("pri" | "at") _SPACE
 random: ("naključno" | "random") _SPACE?
 _IN: _SPACE ("v" | "in") _SPACE

--- a/grammars/keywords-sq.lark
+++ b/grammars/keywords-sq.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("është" | "is") _SPACE
 _STANDALONE_IS: ("është" | "is")
 _SLEEP: ("fle" | "sleep") _SPACE?
 _ADD_LIST: ("shtoni" | "add") _SPACE
-_TO_LIST: _SPACE? ("deri" | "to") _SPACE
+_TO_LIST: _SPACE? ("deri" | "to")
 _REMOVE: ("hiqni" | "remove") _SPACE
-_FROM: _SPACE? ("nga" | "from") _SPACE
+_FROM: _SPACE? ("nga" | "from")
 _AT: _SPACE ("në" | "at") _SPACE
 random: ("rastësi" | "random") _SPACE?
 _IN: _SPACE ("në" | "in") _SPACE

--- a/grammars/keywords-sr.lark
+++ b/grammars/keywords-sr.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("је" | "is") _SPACE
 _STANDALONE_IS: ("је" | "is")
 _SLEEP: ("спавање" | "sleep") _SPACE?
 _ADD_LIST: ("додај" | "add") _SPACE
-_TO_LIST: _SPACE? ("до" | "to") _SPACE
+_TO_LIST: _SPACE? ("до" | "to")
 _REMOVE: ("обриши" | "remove") _SPACE
-_FROM: _SPACE? ("од" | "from") _SPACE
+_FROM: _SPACE? ("од" | "from")
 _AT: _SPACE ("на" | "at") _SPACE
 random: ("насумично" | "random") _SPACE?
 _IN: _SPACE ("у" | "in") _SPACE

--- a/grammars/keywords-sv.lark
+++ b/grammars/keywords-sv.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("är" | "is") _SPACE
 _STANDALONE_IS: ("är" | "is")
 _SLEEP: ("sov" | "sleep") _SPACE?
 _ADD_LIST: ("addera" | "add") _SPACE
-_TO_LIST: _SPACE? ("till" | "to") _SPACE
+_TO_LIST: _SPACE? ("till" | "to")
 _REMOVE: ("radera" | "remove") _SPACE
-_FROM: _SPACE? ("från" | "from") _SPACE
+_FROM: _SPACE? ("från" | "from")
 _AT: _SPACE ("vid" | "at") _SPACE
 random: ("slump" | "random") _SPACE?
 _IN: _SPACE ("i" | "in") _SPACE

--- a/grammars/keywords-sw.lark
+++ b/grammars/keywords-sw.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-ta.lark
+++ b/grammars/keywords-ta.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-te.lark
+++ b/grammars/keywords-te.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("ఉంది" | "is") _SPACE
 _STANDALONE_IS: ("ఉంది" | "is")
 _SLEEP: ("నిద్ర" | "sleep") _SPACE?
 _ADD_LIST: ("జోడించు" | "add") _SPACE
-_TO_LIST: _SPACE? ("కు" | "to") _SPACE
+_TO_LIST: _SPACE? ("కు" | "to")
 _REMOVE: ("తొలగించు" | "remove") _SPACE
-_FROM: _SPACE? ("నుండి" | "from") _SPACE
+_FROM: _SPACE? ("నుండి" | "from")
 _AT: _SPACE ("వద్ద" | "at") _SPACE
 random: ("యాదృచ్ఛికంగా" | "random") _SPACE?
 _IN: _SPACE ("मेలో" | "in") _SPACE

--- a/grammars/keywords-template.lark
+++ b/grammars/keywords-template.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ({is} | "is") _SPACE
 _STANDALONE_IS: ({is} | "is")
 _SLEEP: ({sleep} | "sleep") _SPACE?
 _ADD_LIST: ({add} | "add") _SPACE
-_TO_LIST: _SPACE? ({to_list} | "to") _SPACE
+_TO_LIST: _SPACE? ({to_list} | "to")
 _REMOVE: ({remove} | "remove") _SPACE
-_FROM: _SPACE? ({from} | "from") _SPACE
+_FROM: _SPACE? ({from} | "from")
 _AT: _SPACE ({at} | "at") _SPACE
 random: ({random} | "random") _SPACE?
 _IN: _SPACE ({in} | "in") _SPACE

--- a/grammars/keywords-th.lark
+++ b/grammars/keywords-th.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("คือ" | "is") _SPACE
 _STANDALONE_IS: ("คือ" | "is")
 _SLEEP: ("รอ" | "sleep") _SPACE?
 _ADD_LIST: ("เพิ่ม" | "add") _SPACE
-_TO_LIST: _SPACE? ("ไปยัง" | "to") _SPACE
+_TO_LIST: _SPACE? ("ไปยัง" | "to")
 _REMOVE: ("ลบ" | "remove") _SPACE
-_FROM: _SPACE? ("จาก" | "from") _SPACE
+_FROM: _SPACE? ("จาก" | "from")
 _AT: _SPACE ("แบบ" | "at") _SPACE
 random: ("สุ่ม" | "random") _SPACE?
 _IN: _SPACE ("อยู่ใน" | "in") _SPACE

--- a/grammars/keywords-tl.lark
+++ b/grammars/keywords-tl.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-tn.lark
+++ b/grammars/keywords-tn.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("tsenya" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-tr.lark
+++ b/grammars/keywords-tr.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("eşit" | "is") _SPACE
 _STANDALONE_IS: ("eşit" | "is")
 _SLEEP: ("uyu" | "sleep") _SPACE?
 _ADD_LIST: ("ekle" | "add") _SPACE
-_TO_LIST: _SPACE? ("şuraya" | "to") _SPACE
+_TO_LIST: _SPACE? ("şuraya" | "to")
 _REMOVE: ("kaldır" | "remove") _SPACE
-_FROM: _SPACE? ("şuradan" | "from") _SPACE
+_FROM: _SPACE? ("şuradan" | "from")
 _AT: _SPACE ("içinden" | "at") _SPACE
 random: ("rastgele" | "random") _SPACE?
 _IN: _SPACE ("şunda" | "in") _SPACE

--- a/grammars/keywords-uk.lark
+++ b/grammars/keywords-uk.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("це" | "is") _SPACE
 _STANDALONE_IS: ("це" | "is")
 _SLEEP: ("почекай" | "sleep") _SPACE?
 _ADD_LIST: ("додай" | "add") _SPACE
-_TO_LIST: _SPACE? ("до" | "to") _SPACE
+_TO_LIST: _SPACE? ("до" | "to")
 _REMOVE: ("видали" | "remove") _SPACE
-_FROM: _SPACE? ("iз" | "з" | "from") _SPACE
+_FROM: _SPACE? ("iз" | "з" | "from")
 _AT: _SPACE ("на позиції" | "at") _SPACE
 random: ("випадковий" | "випадковій" | "random") _SPACE?
 _IN: _SPACE ("в" | "in") _SPACE

--- a/grammars/keywords-ur.lark
+++ b/grammars/keywords-ur.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("ہے" | "is") _SPACE
 _STANDALONE_IS: ("ہے" | "is")
 _SLEEP: ("آرام" | "sleep") _SPACE?
 _ADD_LIST: ("شامل" | "add") _SPACE
-_TO_LIST: _SPACE? ("اندر" | "to") _SPACE
+_TO_LIST: _SPACE? ("اندر" | "to")
 _REMOVE: ("نکالو" | "remove") _SPACE
-_FROM: _SPACE? ("سے" | "from") _SPACE
+_FROM: _SPACE? ("سے" | "from")
 _AT: _SPACE ("کوئی" | "at") _SPACE
 random: ("سا" | "random") _SPACE?
 _IN: _SPACE ("میں" | "in") _SPACE

--- a/grammars/keywords-uz.lark
+++ b/grammars/keywords-uz.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("is" | "is") _SPACE
 _STANDALONE_IS: ("is" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("random" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-vi.lark
+++ b/grammars/keywords-vi.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("là" | "is") _SPACE
 _STANDALONE_IS: ("là" | "is")
 _SLEEP: ("sleep" | "sleep") _SPACE?
 _ADD_LIST: ("add" | "add") _SPACE
-_TO_LIST: _SPACE? ("to" | "to") _SPACE
+_TO_LIST: _SPACE? ("to" | "to")
 _REMOVE: ("remove" | "remove") _SPACE
-_FROM: _SPACE? ("from" | "from") _SPACE
+_FROM: _SPACE? ("from" | "from")
 _AT: _SPACE ("at" | "at") _SPACE
 random: ("ngẫu_nhiên" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/keywords-zh_Hans.lark
+++ b/grammars/keywords-zh_Hans.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("是" | "is") _SPACE
 _STANDALONE_IS: ("是" | "is")
 _SLEEP: ("睡眠" | "sleep") _SPACE?
 _ADD_LIST: ("加" | "add") _SPACE
-_TO_LIST: _SPACE? ("到" | "to") _SPACE
+_TO_LIST: _SPACE? ("到" | "to")
 _REMOVE: ("移除" | "remove") _SPACE
-_FROM: _SPACE? ("从" | "from") _SPACE
+_FROM: _SPACE? ("从" | "from")
 _AT: _SPACE ("在" | "at") _SPACE
 random: ("随机" | "random") _SPACE?
 _IN: _SPACE ("在里面" | "in") _SPACE

--- a/grammars/keywords-zh_Hant.lark
+++ b/grammars/keywords-zh_Hant.lark
@@ -26,9 +26,9 @@ _IS: _SPACE ("是" | "is") _SPACE
 _STANDALONE_IS: ("是" | "is")
 _SLEEP: ("睡眠" | "sleep") _SPACE?
 _ADD_LIST: ("加" | "add") _SPACE
-_TO_LIST: _SPACE? ("到" | "to") _SPACE
+_TO_LIST: _SPACE? ("到" | "to")
 _REMOVE: ("移除" | "remove") _SPACE
-_FROM: _SPACE? ("從" | "from") _SPACE
+_FROM: _SPACE? ("從" | "from")
 _AT: _SPACE ("在" | "at") _SPACE
 random: ("隨機" | "random") _SPACE?
 _IN: _SPACE ("in" | "in") _SPACE

--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -35,6 +35,6 @@ function_name: NAME -> text
 ?simple_expression:+= call
 ?turtle_color:+= call
 
-add: _ADD_LIST (atom | list_access | call) _TO_LIST var_access
-remove: _REMOVE (atom | list_access | call) _FROM var_access
+add: _ADD_LIST (atom | list_access | call) _TO_LIST _SPACE var_access
+remove: _REMOVE (atom | list_access | call) _FROM _SPACE var_access
 // ================================================================================

--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -1,4 +1,4 @@
-command:+= assign_list | add | remove | error_add_missing_to | error_remove_missing_from >> error_invalid
+command:+= assign_list | add | remove | error_add_missing_to | error_remove_missing_from | error_add_missing_list | error_remove_missing_list >> error_invalid
 _print_ask_argument: (_SPACE | (list_access textwithoutspaces?) | textwithoutspaces)*
 
 assign: var _IS (list_access | text) -> assign
@@ -18,7 +18,9 @@ text_list: /([^\n,،，、#]+)/ -> text // list elements are another exception s
 // It means that a space cannot be not followed by a 'to' or 'from' for the given language
 text_add_remove_list: /(?:[^\n,،，、# ]| (?!<expand_keyword to_list>|<expand_keyword from>))+/ -> text
 
-add: _ADD_LIST text_add_remove_list _TO_LIST var_access
-remove: _REMOVE text_add_remove_list _FROM var_access
-error_add_missing_to: _ADD_LIST var_access
-error_remove_missing_from: _REMOVE var_access
+add: _ADD_LIST text_add_remove_list _TO_LIST _SPACE var_access
+remove: _REMOVE text_add_remove_list _FROM _SPACE var_access
+error_add_missing_to: _ADD_LIST text_add_remove_list _SPACE?
+error_remove_missing_from: _REMOVE text_add_remove_list _SPACE?
+error_add_missing_list: _ADD_LIST text_add_remove_list _TO_LIST _SPACE?
+error_remove_missing_list: _REMOVE text_add_remove_list _FROM _SPACE?

--- a/grammars/level4-Additions.lark
+++ b/grammars/level4-Additions.lark
@@ -1,5 +1,5 @@
 // redefining it entirely since it has many order-depending rules (e.g ask_no_quotes should be after ask and before assign)
-command: clear | error_non_decimal | print | ask | play | turtle | assign_list | add | remove | error_add_missing_to | error_remove_missing_from | sleep | error_list_access | error_ask_no_quotes| assign | error_invalid_space | error_print_no_quotes | error_print_one_quote_only | error_text_no_print |error_invalid | empty_line
+command: clear | error_non_decimal | print | ask | play | turtle | assign_list | add | remove | error_add_missing_to | error_remove_missing_from | error_add_missing_list | error_remove_missing_list | sleep | error_list_access | error_ask_no_quotes| assign | error_invalid_space | error_print_no_quotes | error_print_one_quote_only | error_text_no_print |error_invalid | empty_line
 
 _print_ask_argument.1: (_SPACE | list_access | error_list_access | quoted_text | var_access_print)*
 

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -2,7 +2,7 @@ _print_ask_argument.1: (_SPACE | quoted_text | list_access | expression | print_
 ?print_expression: var_access_print | error_unsupported_number | INT
 
 // redefining it entirely since it has many order-depending rules
-command: clear | error_non_decimal | print | turtle | play | add | remove | error_add_missing_to | error_remove_missing_from | sleep | error_print_no_quotes | error_print_one_quote_only | if_pressed_else | error_if_pressed_missing_else | if_pressed_without_else | ifelse | ifs | error_else_no_if | ask | error_ask_no_quotes | assign | assign_list | error_invalid_space | error_text_no_print | empty_line
+command: clear | error_non_decimal | print | turtle | play | add | remove | error_add_missing_to | error_remove_missing_from | error_add_missing_list | error_remove_missing_list | sleep | error_print_no_quotes | error_print_one_quote_only | if_pressed_else | error_if_pressed_missing_else | if_pressed_without_else | ifelse | ifs | error_else_no_if | ask | error_ask_no_quotes | assign | assign_list | error_invalid_space | error_text_no_print | empty_line
 _if_less_command: print | turtle | play | add | remove | sleep | error_print_no_quotes | error_print_one_quote_only | ask | error_ask_no_quotes | assign | assign_list
 
 ask: var (_IS | _EQUALS) _ASK _SPACE? (_print_ask_argument)?
@@ -16,8 +16,8 @@ condition: >> equality_check
 assign_list: var (_IS | _EQUALS) (INT | textwithspaces) (_COMMA (INT | textwithspaces))+
 assign: var (_IS | _EQUALS) (INT | list_access | expression | textwithoutspaces | textwithspaces)
 
-add: _ADD_LIST (INT | text_add_remove_list) _TO_LIST var_access
-remove: _REMOVE (INT | text_add_remove_list) _FROM var_access
+add: _ADD_LIST (INT | text_add_remove_list) _TO_LIST _SPACE var_access
+remove: _REMOVE (INT | text_add_remove_list) _FROM _SPACE var_access
 
 sleep: _SLEEP (INT | list_access | var_access | expression)?
 

--- a/hedy.py
+++ b/hedy.py
@@ -1308,6 +1308,13 @@ class IsValid(Filter):
     def error_remove_missing_from(self, meta, args):
         raise exceptions.MissingAdditionalCommand(command='remove', missing_command='from', line_number=meta.line)
 
+    def error_add_missing_list(self, meta, args):
+        raise exceptions.IncompleteCommandException(incomplete_command='add', level=self.level, line_number=meta.line)
+
+    def error_remove_missing_list(self, meta, args):
+        raise exceptions.IncompleteCommandException(incomplete_command='remove', level=self.level,
+                                                    line_number=meta.line)
+
     def error_non_decimal(self, meta, args):
         raise exceptions.NonDecimalVariable(line_number=meta.line)
 

--- a/tests/test_level/test_level_03.py
+++ b/tests/test_level/test_level_03.py
@@ -931,6 +931,20 @@ class TestsLevel3(HedyTester):
             exception=hedy.exceptions.InvalidArgumentTypeException
         )
 
+    def test_add_to_list_without_list_gives_error(self):
+        code = textwrap.dedent("""\
+        animals is dog, cat, kangaroo
+        add favorite to
+        print animals at random""")
+
+        self.multi_level_tester(
+            max_level=11,
+            skip_faulty=False,
+            code=code,
+            extra_check_function=lambda c: c.exception.arguments['line_number'] == 2,
+            exception=hedy.exceptions.IncompleteCommandException
+        )
+
     def test_remove_from_list_with_input_var_gives_error(self):
         code = textwrap.dedent("""\
         colors is ask 'What are the colors?'
@@ -956,6 +970,20 @@ class TestsLevel3(HedyTester):
             code=code,
             extra_check_function=lambda c: c.exception.arguments['line_number'] == 2,
             exception=hedy.exceptions.MissingAdditionalCommand
+        )
+
+    def test_remove_from_list_without_list_gives_error(self):
+        code = textwrap.dedent("""\
+        animals is dog, cat, kangaroo
+        remove dog from
+        print animals at random""")
+
+        self.multi_level_tester(
+            max_level=11,
+            skip_faulty=False,
+            code=code,
+            extra_check_function=lambda c: c.exception.arguments['line_number'] == 2,
+            exception=hedy.exceptions.IncompleteCommandException
         )
 
     #

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "البرنامج الخاص بك غير مكتمل. عليك أن تست
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "البرنامج الخاص بك غير مكتمل. عليك أن تست
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "أوه! لقد نسيت أن تكمل جزءاً من البرنامج! في السطر رقم {line_number}، عليك أن تكمل كتابة الكود بعد `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -38,7 +38,7 @@ msgstr "Кодът ти е непълен. Съдържа празни мест�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -38,7 +38,7 @@ msgstr "Кодът ти е непълен. Съдържа празни мест�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Момент, кодът ти не е пълен! На ред {line_number} е нужно да напишеш текст след `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -78,7 +78,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}।"
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Hem detectat que el teu codi sembla incomplet. Pots assegurar-te que has omplert tots els espais en blanc?"
 
 msgid "Incomplete"
-msgstr "Hem detectat que falta una part del teu codi des de`{incomplete_command}` a la línia {line_number}. Pots intentar afegir allò que falta?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Hem detectat que al `{repeat}` de la línia {line_number} li falta una comanda`{command}`. Pots afegir-la?"
@@ -65,7 +65,7 @@ msgid "Lonely Text"
 msgstr "Hem detectat al codi que fa falta una comanda dins el text de la línia {line_number}. Pots provar d'escriure dins el text la comanda que hi falta"
 
 msgid "Missing Additional Command"
-msgstr "Hem detectat al codi que fa falta una `{command}` a la línia {line_number}. Pots provar d'utilitzar `{missing_command}` al teu codi."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "Hem detectat que `{command}` necessita dos punts (`:`) al final de la línia {line_number}. A partir del nivell 17, recordareu d'afegir `:` als finals de línies amb comandes?"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Hem detectat que el teu codi sembla incomplet. Pots assegurar-te que has omplert tots els espais en blanc?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Hem detectat que al `{repeat}` de la línia {line_number} li falta una comanda`{command}`. Pots afegir-la?"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Jejda, zapomněl*a jsi kousek kódu! Na řádku {line_number} musíš ještě něco dopsat za `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Wir haben bemerkt, dass dein Programm leer ist. Kannst du die Leerzeichen mit Programm füllen?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Wir haben festgestellt, dass dem {repeat} Befehl in Zeile{line_number} ein `{command}` Befehl fehlt. Kannst du probieren, es hinzuzufügen?"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Wir haben bemerkt, dass dein Programm leer ist. Kannst du die Leerzeichen mit Programm füllen?"
 
 msgid "Incomplete"
-msgstr "Wir haben festgestellt, dass ein Teil des Codes vom {incomplete_command} Befehl in Zeile {line_number} zu fehlen scheint. Kannst du probieren, den fehlenden Code hinzuzufügen?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Wir haben festgestellt, dass dem {repeat} Befehl in Zeile{line_number} ein `{command}` Befehl fehlt. Kannst du probieren, es hinzuzufügen?"
@@ -69,7 +69,7 @@ msgstr "Es sieht so aus als ob du vergessen hast einen Befehl für deinen Text i
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -40,7 +40,7 @@ msgstr "Ο κώδικάς σου δεν είναι πλήρης. Περιέχε�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -40,7 +40,7 @@ msgstr "Ο κώδικάς σου δεν είναι πλήρης. Περιέχε�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ουπς! Ξέχασες ένα κομμάτι κώδικα! Στη γραμμή {line_number}, πρέπει να γράψεις κείμενο ύστερα από την `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -80,7 +80,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -64,7 +64,7 @@ msgid "Lonely Text"
 msgstr "We detected that the code seems to be missing a command with the text that was used in line {line_number}. Can you try writing the needed command with the text"
 
 msgid "Missing Additional Command"
-msgstr "We detected that the code seems to be missing a `{command}` on line {line_number}. Can you try using `{missing_command}` in your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "We detected that `{command}` needs a `:` at the end of line {line_number}. Starting from level 17, can you start adding a `:` at the end of line with commands?"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -34,7 +34,7 @@ msgid "Has Blanks"
 msgstr "We detected that the code seems to be incomplete. Can you fill in the blanks with code?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "We detected that the `{repeat}` on line {line_number} is missing a `{command}` command. Can you try adding it?"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Via kodo ne estas kompleta. Ĝi enhavas spacojn kiun vi devas anstataŭi
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ups! Vi forgesis parton de kodo! Je la linio {line_number} vi bezonas enigi tekston post `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Via kodo ne estas kompleta. Ĝi enhavas spacojn kiun vi devas anstataŭi
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Detectamos que el código parece estar incompleto. ¿Puede rellenar los espacios en blanco con código?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Detectamos que el `{repeat}` en la línea {line_number} está faltando un `{command}`comando. ¿Puede intentar agregarlo?"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Detectamos que el código parece estar incompleto. ¿Puede rellenar los espacios en blanco con código?"
 
 msgid "Incomplete"
-msgstr "Detectamos que parte del código parece estar faltando en el `{incomplete_command}` en la línea {line_number}. ¿Puede intentar agregar lo que falta?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Detectamos que el `{repeat}` en la línea {line_number} está faltando un `{command}`comando. ¿Puede intentar agregarlo?"
@@ -65,7 +65,7 @@ msgid "Lonely Text"
 msgstr "Detectamos que el código parece estar faltando un comando con el texto que se utilizó en la línea {line_number}. Puedes intentar escribir el comando necesario con el texto"
 
 msgid "Missing Additional Command"
-msgstr "Detectamos que el código parece estar faltando un `{command}`en la línea {line_number}. ¿Puedes intentar usar `{missing_command}` en su código."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "Detectamos que `{command}`necesita un `:`al final de la línea {line_number}. A partir del nivel 17, ¿puedes empezar a añadir un «:» al final de la línea con comandos?"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Su kood ei ole veel valmis. Seal on veel tühjad kohad, kuhu sa pead koo
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ups! Sa jätsid natukene koodi kirjutamata! {line_number} real pead sa pärast `{incomplete_command}` midagi kirjutama."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Su kood ei ole veel valmis. Seal on veel tühjad kohad, kuhu sa pead koo
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Ton code est incomplet. Il contient des blancs que tu dois remplacer par
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oups ! Tu as oublié un morceau du code ! À la ligne {line_number}, tu dois ajouter du texte après `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "Il semble que tu as oublié de mettre une commande avec le texte de la l
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Ton code est incomplet. Il contient des blancs que tu dois remplacer par
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fr_CA/LC_MESSAGES/messages.po
+++ b/translations/fr_CA/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/fr_CA/LC_MESSAGES/messages.po
+++ b/translations/fr_CA/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Tink der om! Dyn koade is noch net ôf. Der stiet noch leech streepke yn
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Tink der om! Dyn koade is noch net ôf. Der stiet noch leech streepke yn
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Tink derom, bist wat koade fergetten. Op rigel {line_number} moat der efter `{incomplete_command}` noch tekst komme."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "आपका कोड अधूरा है। इसमें रि�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "आपका कोड अधूरा है। इसमें रि�
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "उफ़! आप थोड़ा सा कोड भूल गए! लाइन {line_number} पर, आपको `{incomplete_command}` के पीछे टेक्स्ट डालना होगा|"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}।"
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/hr/LC_MESSAGES/messages.po
+++ b/translations/hr/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "We detected that the code seems to be incomplete. Can you fill in the bl
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "A kódod hiányos. Tartalmaz üres helyeket, amelyeket kóddal kell hely
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Hoppá! Elfelejtettél egy kis kódot! A(z) {line_number}. sorban, szöveget kell beírnod a(z) `{incomplete_command}` parancs mögé."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "A(z) {line_number}. sorban csak szöveg van, úgy tűnik elfelejtettél 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "A kódod hiányos. Tartalmaz üres helyeket, amelyeket kóddal kell hely
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/iba/LC_MESSAGES/messages.po
+++ b/translations/iba/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/iba/LC_MESSAGES/messages.po
+++ b/translations/iba/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "Kode Anda tidak lengkap. Ini berisi bagian kosong yang harus Anda ganti 
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ups! Anda sedikit lupa kodenya! Pada baris {line_number}, Anda perlu memasukkan teks di belakang `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -93,7 +93,7 @@ msgstr "Sepertinya Anda lupa menggunakan perintah dengan teks yang Anda gunakan 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "Kode Anda tidak lengkap. Ini berisi bagian kosong yang harus Anda ganti 
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Il tuo codice è incompleto. Contiene spazi vuoti che devi sostituire co
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ops! Hai dimenticato un po' di codice! Alla riga {line_number}, devi inserire il testo dietro `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Il tuo codice è incompleto. Contiene spazi vuoti che devi sostituire co
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "あたなのコードは、完全に終わっていません。空白の
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "おおっと! 少しコードを忘れていますよ！{line_number}行の`{incomplete_command}`の後に、テキストを入力して下さい。"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "あたなのコードは、完全に終わっていません。空白の
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "코드가 불완전합니다. 코드로 대체해야하는 빈칸이 들
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "코드가 불완전합니다. 코드로 대체해야하는 빈칸이 들
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "이런! 코드를 조금 잊으셨군요! {line_number} 라인에서 `{incomplete_command}` 뒤에 텍스트를 입력해야 합니다."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "{line_number} 행에서 사용한 텍스트에 명령을 사용하지 �
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ms/LC_MESSAGES/messages.po
+++ b/translations/ms/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ms/LC_MESSAGES/messages.po
+++ b/translations/ms/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Koden din er uferdig. Den inneholder tomrom du må erstatte med kode."
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Koden din er uferdig. Den inneholder tomrom du må erstatte med kode."
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oisann! Du glemte litt kode! På linje {line_number}, må du legge til tekst etter `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ne/LC_MESSAGES/messages.po
+++ b/translations/ne/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "We detected that the code seems to be incomplete. Can you fill in the bl
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -39,7 +39,7 @@ msgstr "Je code is onvolledig. Er zijn nog invulplaatsen die je moet vervangen d
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Let op, je bent een stukje code vergeten. Op regel {line_number} moet er achter `{incomplete_command}` nog tekst komen."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -79,7 +79,7 @@ msgstr "Het lijkt erop dat je bent vergeten bent een commando te gebruiken in de
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "Het lijkt erop dat je `{command}` niet volledig hebt geschreven op regel {line_number}. Probeer `{missing_command}` toe te voegen aan je code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -39,7 +39,7 @@ msgstr "Je code is onvolledig. Er zijn nog invulplaatsen die je moet vervangen d
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/peo/LC_MESSAGES/messages.po
+++ b/translations/peo/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/peo/LC_MESSAGES/messages.po
+++ b/translations/peo/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -36,7 +36,7 @@ msgid "Has Blanks"
 msgstr "Wykryliśmy, że kod wydaje się niekompletny. Czy możesz wypełnić puste miejsca kodem?"
 
 msgid "Incomplete"
-msgstr "Wykryliśmy, że wydaje się, że brakuje części kodu w poleceniu {incomplete_command}w wierszu {line_number}. Czy możesz spróbować dodać to, czego brakuje?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Wykryliśmy, że w wierszu{repeat} w wierszu {line_number} brakuje polecenia {command}. Czy możesz spróbować go dodać?"
@@ -66,7 +66,7 @@ msgid "Lonely Text"
 msgstr "Wykryliśmy, że w kodzie brakuje polecenia z tekstem użytym w wierszu {line_number}. Czy możesz spróbować napisać potrzebne polecenie z tekstem"
 
 msgid "Missing Additional Command"
-msgstr "Wykryliśmy, że w kodzie brakuje polecenia {command} w wierszu {line_number}. Czy możesz spróbować użyć {missing_command} w swoim kodzie."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "Wykryliśmy, że {command} potrzebuje `:` na końcu wiersza {line_number}. Zaczynając od poziomu 17, czy możesz zacząć dodawać `:` na końcu wiersza za pomocą poleceń?"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -36,7 +36,7 @@ msgid "Has Blanks"
 msgstr "Wykryliśmy, że kod wydaje się niekompletny. Czy możesz wypełnić puste miejsca kodem?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Wykryliśmy, że w wierszu{repeat} w wierszu {line_number} brakuje polecenia {command}. Czy możesz spróbować go dodać?"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Seu codigo esta incompleto. Ele contém espaços em branco que precisam 
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Opa! Você esqueceu uma parte do código! Na linha {line_number}, você precisa colocar texto antes de `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "Parece que você esqueceu de usar um comando com o texto que você usou 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "Parece que você esqueceu de terminar de escrever `{command}` na linha {line_number}. Tente adicionar `{missing_command}` a seu código."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Seu codigo esta incompleto. Ele contém espaços em branco que precisam 
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! Esqueceste-te de um pedaço de código! Na linha {line_number}, tens de introduzir texto a seguir de `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Ваша программа не готова. В ней есть про
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Ваша программа не готова. В ней есть про
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ой-ой! На строке {line_number} нужно дописать что-то ещё после `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "Кажется, вы забыли использовать команд�
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Vaša koda je nepopolna. Vsebuje prazna mesta, ki jih morate nadomestiti
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ups! Pozabili ste del kode! V vrstici {line_number} morate za `{incomplete_command}` vnesti besedilo."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}. Try adding `{missing_command}` to your code."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Vaša koda je nepopolna. Vsebuje prazna mesta, ki jih morate nadomestiti
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Открили смо да код изгледа непотпун. Можете ли попунити празнине кодом?"
 
 msgid "Incomplete"
-msgstr "Открили смо да део кода изгледа недостаје у `{incomplete_command}` на линији {line_number}. Можете ли покушати да додате оно што недостаје?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Открили смо да `{repeat}` на линији {line_number} недостаје команда `{command}`. Можете ли покушати да је додате?"
@@ -65,7 +65,7 @@ msgid "Lonely Text"
 msgstr "Открили смо да код изгледа да недостаје команда са текстом који је коришћен у линији {line_number}. Можете ли покушати да напишете потребну команду са текстом"
 
 msgid "Missing Additional Command"
-msgstr "Открили смо да коду изгледа недостаје `{command}` на линији {line_number}. Можете ли покушати да користите `{missing_command}` у свом коду."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "Открили смо да `{command}` треба `:` на крају линије {line_number}. Почевши од нивоа 17, можете ли почети да додајете `:` на крају линије са командама?"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Открили смо да код изгледа непотпун. Можете ли попунити празнине кодом?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Открили смо да `{repeat}` на линији {line_number} недостаје команда `{command}`. Можете ли покушати да је додате?"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Din kod är ofullständig. Den innehåller tomrum som du måste ersätta
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Din kod är ofullständig. Den innehåller tomrum som du måste ersätta
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Hoppsan! Du glömde lite kod! På rad {line_number} måste du ange text efter `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "Du verkar ha glömt att använda ett kommando ihop med texten du använd
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! Umesahau kitu! Kwenye mstari wa {line_number}, unatakiwa kuandika nyuma ya `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ta/LC_MESSAGES/messages.po
+++ b/translations/ta/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "We detected that the code seems to be incomplete. Can you fill in the bl
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Kodun tamamlanmamış gibi göründüğünü tespit ettik. Boşlukları doldurabilir misiniz?"
 
 msgid "Incomplete"
-msgstr "Satır {line_number}'deki/daki `{incomplete_command}` komutunun bir kısmının eksik olduğunu tespit ettik. Eksik olan kısmı eklemeyi deneyebilir misiniz?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Satır {line_number}'daki `{repeat}` ifadesinin yanında bir `{command}` komutunun eksik olduğunu tespit ettik. Eksik komutu eklemeyi deneyebilir misiniz?"
@@ -65,7 +65,7 @@ msgid "Lonely Text"
 msgstr "Kodun, satır {line_number}'de/da kullanılan metinle ilgili bir komut eksik olduğunu tespit ettik. Gerekli komutu metinle birlikte yazmayı deneyebilir misiniz?"
 
 msgid "Missing Additional Command"
-msgstr "Kodunun, satır {line_number}'de/da bir `{command}` eksik olduğunu tespit ettik. Kodunuzda `{missing_command}` kullanmayı deneyebilir misiniz?"
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "`{command}` ifadesesinin satır {line_number}'nin sonunda bir `:` işaretine ihtiyacı olduğunu tespit ettik. 17. seviyeden itibaren komutların sonuna `:` eklemeye başlayabilir misiniz?"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "Kodun tamamlanmamış gibi göründüğünü tespit ettik. Boşlukları doldurabilir misiniz?"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "Satır {line_number}'daki `{repeat}` ifadesinin yanında bir `{command}` komutunun eksik olduğunu tespit ettik. Eksik komutu eklemeyi deneyebilir misiniz?"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Ваш код є неповним. Він містить пробіли,
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Ой! Ви забули трохи коду! У рядку {line_number} потрібно ввести текст за `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -82,7 +82,7 @@ msgstr "Схоже, що ви забули використати команду
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr "Ваш код є неповним. Він містить пробіли,
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "آپ کا کوڈ نامکمل ہے۔اس میں خالی جگہیں مو
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "آپ کا کوڈ نامکمل ہے۔اس میں خالی جگہیں مو
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -81,7 +81,7 @@ msgstr "It looks like you forgot to use a command with the text you put in line 
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/uz/LC_MESSAGES/messages.po
+++ b/translations/uz/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr "We detected that the code seems to be incomplete. Can you fill in the bl
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -37,7 +37,7 @@ msgstr "Chúng tôi phát hiện chương trình của bạn chưa hoàn thiện
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -37,7 +37,7 @@ msgstr "Chúng tôi phát hiện chương trình của bạn chưa hoàn thiện
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -77,7 +77,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "我们发现代码似乎不完整。能能用代码填补空白吗？"
 
 msgid "Incomplete"
-msgstr "我们发现第 {line_number} 行的 `{incomplete_command}` 部分代码似乎缺失。你可以尝试添加缺失的内容吗？"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "我们检测到第 {line_number} 行的 `{repeat}` 缺少 `{command}` 命令。你可以尝试添加它吗？"
@@ -65,7 +65,7 @@ msgid "Lonely Text"
 msgstr "我们检测到代码中似乎缺少一个包含第 {line_number} 行所用文本的命令。你能否尝试使用文本编写所需的命令"
 
 msgid "Missing Additional Command"
-msgstr "我们发现代码第 {line_number} 行似乎缺少 `{command}`。您能否尝试在代码中使用 `{missing_command}`。"
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 msgid "Missing Colon Error"
 msgstr "我们检测到 `{command}` 在第 {line_number} 行末尾需要一个 `:`。从第 17 级开始，你可以在命令行末尾添加 `:` ？"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -35,7 +35,7 @@ msgid "Has Blanks"
 msgstr "我们发现代码似乎不完整。能能用代码填补空白吗？"
 
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 msgid "Incomplete Repeat"
 msgstr "我们检测到第 {line_number} 行的 `{repeat}` 缺少 `{command}` 命令。你可以尝试添加它吗？"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -40,7 +40,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind `{incomplete_command}`."
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"
@@ -80,7 +80,7 @@ msgstr "It looks like you forgot to use a command with the text you used in line
 
 #, fuzzy
 msgid "Missing Additional Command"
-msgstr "It looks like you forgot to complete writing `{command}` on line {line_number}."
+msgstr "We detected that the command `{command}` on line {line_number} is missing something. Can you try using `{missing_command}` in your code?"
 
 #, fuzzy
 msgid "Missing Colon Error"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -40,7 +40,7 @@ msgstr "Your code is incomplete. It contains blanks that you have to replace wit
 
 #, fuzzy
 msgid "Incomplete"
-msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding the what's missing?"
+msgstr "We detected that part of the code seems to be missing from the `{incomplete_command}` on line {line_number}. Can you try adding what's missing?"
 
 #, fuzzy
 msgid "Incomplete Repeat"


### PR DESCRIPTION
This PR adds a specific error message when the user forgot to add a list at the end of the add-to and remove-from commands. Previously, we displayed a generic error that something is off with the line:
_We detected that Add is being used on line 3 which is not allowed. Can you try looking for a missing or an extra character on your code?_

Now we changed it to: _We detected that part of the code seems to be missing from the Add on line 3. Can you try adding the what's missing_

Fixes #5871

**How to test**
Go to level 3 and execute the following commands:
```
houses is Gryffindor, Hufflepuf, Ravenclaw, Slytherin
dislike is Slytherin
remove dislike from
```
and
```
houses is Gryffindor, Hufflepuf, Ravenclaw, Slytherin
dislike is Slytherin
remove dislike
```
Check that you agree with the error messages.