### PR TITLE
🖊️ Allow assigning list access to list access 

### DIFF
--- a/grammars/level16-Additions.lark
+++ b/grammars/level16-Additions.lark
@@ -4,7 +4,7 @@ command:+= change_list_item | error_assign_list_missing_brackets
 
 ?atom: NUMBER | _MINUS NUMBER | boolean | list_access | text_in_quotes | var_access
 list_access: var_access _LEFT_SQUARE_BRACKET (INT | random | var_access) _RIGHT_SQUARE_BRACKET
-change_list_item: var_access _LEFT_SQUARE_BRACKET (INT | var_access) _RIGHT_SQUARE_BRACKET _EQUALS (var_access | quoted_text | NUMBER | boolean)
+change_list_item: var_access _LEFT_SQUARE_BRACKET (INT | var_access) _RIGHT_SQUARE_BRACKET _EQUALS (var_access | quoted_text | NUMBER | boolean | list_access)
 assign_list: var (_IS | _EQUALS) _LEFT_SQUARE_BRACKET ((quoted_text | NUMBER | boolean) (_COMMA (quoted_text | NUMBER | boolean))*)? _RIGHT_SQUARE_BRACKET
 error_assign_list_missing_brackets: var  (_IS | _EQUALS) (_LEFT_SQUARE_BRACKET)? ((quoted_text | NUMBER | boolean) _COMMA (quoted_text | NUMBER | boolean) (_COMMA (quoted_text | NUMBER | boolean))*)? (_RIGHT_SQUARE_BRACKET)?
 

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -518,6 +518,34 @@ class TestsLevel16(HedyTester):
 
         self.single_level_tester(code=code, expected=expected)
 
+    def test_change_list_item_to_list_access(self):
+        code = textwrap.dedent("""\
+        a = [1, 2]
+        b = [3, 4]
+        a[1] = b[2]""")
+
+        expected = self.dedent(
+            "a = Value([Value(1, num_sys='Latin'), Value(2, num_sys='Latin')])",
+            "b = Value([Value(3, num_sys='Latin'), Value(4, num_sys='Latin')])",
+            self.list_access_transpiled('a.data[int(1)-1]'),
+            "a.data[int(1)-1] = b.data[int(2)-1]")
+
+        self.multi_level_tester(code=code, expected=expected)
+
+    def test_change_list_item_to_random_list_access(self):
+        code = textwrap.dedent("""\
+        a = [1, 2]
+        b = [3, 4]
+        a[1] = b[random]""")
+
+        expected = self.dedent(
+            "a = Value([Value(1, num_sys='Latin'), Value(2, num_sys='Latin')])",
+            "b = Value([Value(3, num_sys='Latin'), Value(4, num_sys='Latin')])",
+            self.list_access_transpiled('a.data[int(1)-1]'),
+            "a.data[int(1)-1] = random.choice(b.data)")
+
+        self.multi_level_tester(code=code, expected=expected)
+
     def test_assign_list_missing_brackets_gives_error(self):
         code = textwrap.dedent("""\
         animals = 'chicken', 'horse', 'cow'


### PR DESCRIPTION
This PR allows in level 16 to assign a list element another list element, e.g. `a[1] = b[2]`

Fixes #5758

**How to test**
Go to level 16 and try the following code:
```
kassa_munten = [1,1,1,1,1,1]
random_aantal_muntjes = [2,3,4,5, 6]
kassa_munten[1] = random_aantal_muntjes[random]
print kassa_munten[1]
```
Ensure that it works without errors