### PR TITLE
📜 Remove empty content from adventures

### DIFF
--- a/content/adventures/en.yaml
+++ b/content/adventures/en.yaml
@@ -4920,7 +4920,6 @@ adventures:
                         Square <img src="https://github.com/hedyorg/hedy/assets/80678586/03b96c2c-7b94-4032-9f9f-3f3b13573623" width="200">
                         Stairs<img src="https://github.com/hedyorg/hedy/assets/80678586/d4301e62-ec66-4031-827c-7d21f73ba106" width="200">
                     </div>
-                example_code: ''
             2:
                 story_text: |
                     ### Exercise
@@ -4931,7 +4930,6 @@ adventures:
                     Arrow <img src="https://github.com/hedyorg/hedy/assets/80678586/803d8f42-9708-448c-82ea-d035697f08c9" width="150">
                     Boat <img src="https://github.com/hedyorg/hedy/assets/80678586/94ef7189-442a-4c8f-827d-12a69203c2e9" width="150">
                     </div>
-                example_code: ''
             3:
                 story_text: |
                     ### Exercise
@@ -4942,7 +4940,6 @@ adventures:
                     Star <img src="https://github.com/hedyorg/hedy/assets/80678586/421c4d28-cb99-424b-be26-dcae30d65c80" width="150">
                     Arrow <img src="https://github.com/hedyorg/hedy/assets/80678586/3cbebcae-5258-47c5-a6ac-e7ee36c1d1ce" width="200">
                     </div>
-                example_code: ''
             4:
                 story_text: |
                     ### Exercise
@@ -5007,7 +5004,6 @@ adventures:
                     Triangle <img src="https://github.com/hedyorg/hedy/assets/80678586/3629a5e6-1f02-4851-aab9-c5430ba4a1f1" width="200">
                     Fan <img src="https://github.com/hedyorg/hedy/assets/80678586/1ba2ff71-1230-4fe3-8255-b2c504cf1b4e" width="200">
                     </div>
-                example_code: ''
             8:
                 story_text: |
                     ### Exercise
@@ -5020,7 +5016,6 @@ adventures:
                     Randomly colored star (5) <img src="https://github.com/hedyorg/hedy/assets/80678586/dbe39006-c050-4833-b5c4-f9d1fb1c0781" width="150">
                     Randomly colored spiral (7) <img src="https://github.com/hedyorg/hedy/assets/80678586/9bcdb3f1-367d-4ae0-878f-d09005424a35" width="150">
                     </div>
-                example_code: ''
             9:
                 story_text: |
                     ### Exercise


### PR DESCRIPTION
This PR removes 5 nodes from the adventures yaml content with empty values, so that they do not show up for translation in Weblate.

Fixes #5890 

**How to test**
The Draw It! adventures should load correctly for levels 1, 2, 3, 7 and 8 and without an example code snippet.