### PR TITLE
💻 Small changes to the create accounts in bulk interface

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-06-26 16:04+0200\n"
+"POT-Creation-Date: 2024-10-28 19:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1265,6 +1265,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -1908,6 +1911,9 @@ msgid "waiting_for_submit"
 msgstr ""
 
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/static/js/teachers.ts
+++ b/static/js/teachers.ts
@@ -566,26 +566,39 @@ export function toggleAutoGeneratePasswords() {
     }
 }
 
-export function printAccounts() {
+export function printAccounts(title: string) {
     var table = document.getElementById("accounts_table");
     let newWindow = window.open("")!;
     const css = `
     <style>
-      @media print {
-        #accounts_table {
-          margin-top: 50px;
-          border-collapse: collapse;
-        }
-        #accounts_table td, th {
-          padding-left: 10px;
-          padding-right: 10px;
-          padding-top: 5px;
-          padding-bottom: 5px;
-          font-size: 24px;
-          border: 1px solid gray;
-        }
+      h1 {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        margin-left: 20px;
+        color: rgb(44 82 130);
+      }
+
+      #accounts_table {
+        border-collapse: collapse;
+      }
+
+      #accounts_table td, th {
+        padding-left: 1.25rem;
+        padding-right: 1.25rem;
+        padding-top: 1.25rem;
+        padding-bottom: 1.25rem;
+        font-size: 1.5rem;
+        border: 1px solid gray;
+        color: rgb(44 82 130);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        text-align: center;
       }
     </style>`;
+    newWindow.document.write(`
+        <div style="display: flex; margin-bottom: 20px;">
+          <img src="/images/hero-graphic/hero-graphic-empty.png" height="100">
+          <h1>${title}</h1>
+        </div>
+    `);
     newWindow.document.write(table?.outerHTML + css);
     newWindow.print();
     newWindow.close();
@@ -661,7 +674,8 @@ function createHtmlForAccountsTable(accounts: Array<any>) {
     let result = ""
     for (let [index, account] of accounts.entries()) {
         result += `
-          <tr class="${ index%2 ? 'bg-white' : 'bg-gray-200'}">
+          <tr class="${ index%2 ? 'bg-white' : 'bg-gray-200'} font-mono">
+            <td class="text-center px-4 py-2">hedy.org</td>
             <td class="text-center px-4 py-2">${account['username']}</td>
             <td class="text-center px-4 py-2">${account['password']}</td>
           </tr>`;

--- a/templates/create-accounts.html
+++ b/templates/create-accounts.html
@@ -52,23 +52,23 @@
             </div>
         </form>
 
-        <div id="accounts_results" class="w-1/2 gap-4 mt-4 items-center hidden">
+        <div id="accounts_results" class="gap-4 mt-4 items-center hidden">
             <div class="flex flex-row gap-4">
                 <button id="copy_accounts" class="blue-btn px-4 mb-3" onclick="hedyApp.copyAccountsToClipboard('{{_('copy_clipboard')}}')">
                   {{_('copy_accounts_to_clipboard')}}
                 </button>
-                <button id="print_accounts" class="blue-btn px-4 mb-3" onclick="hedyApp.printAccounts()">
+                <button id="print_accounts" class="blue-btn px-4 mb-3"
+                        onclick="hedyApp.printAccounts('{{_('print_accounts_title')}}')">
                   {{_('print_accounts')}}
                 </button>
             </div>
-            <div class="overflow-x-auto rounded-lg shadow-lg">
-                <table id="accounts_table" data-cy="create_accounts_output" class="w-full border border-gray-400">
-                    <tr class="bg-blue-300 text-blue-900">
-                        <th class="px-10 py-2 text-center">{{_('username')}}</th>
-                        <th class="px-10 py-2 text-center">{{_('password')}}</th>
-                    </tr>
-                </table>
-            </div>
+            <table id="accounts_table" data-cy="create_accounts_output" class="border border-gray-400">
+                <tr class="bg-blue-300 text-blue-900">
+                    <th class="px-10 py-2 text-center">{{_('website')}}</th>
+                    <th class="px-10 py-2 text-center">{{_('username')}}</th>
+                    <th class="px-10 py-2 text-center">{{_('password')}}</th>
+                </tr>
+            </table>
         </div>
     </div>
 </div>

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1496,6 +1496,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "قول"
 
@@ -2194,7 +2197,7 @@ msgstr "اسم المستخدم"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2245,6 +2248,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -1617,6 +1617,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "принтирай"
 
@@ -2382,7 +2385,7 @@ msgstr "Потребителско име"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2435,6 +2438,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -1689,6 +1689,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2494,7 +2497,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2550,6 +2553,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -1505,6 +1505,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "imprimir"
 
@@ -2215,7 +2218,7 @@ msgstr "Nom d'usuari"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2265,6 +2268,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -1627,6 +1627,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2395,7 +2398,7 @@ msgstr "Uživatelské jméno"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2449,6 +2452,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -1678,6 +1678,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "argraffu"
 
@@ -2482,7 +2485,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2538,6 +2541,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -1682,6 +1682,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2492,7 +2495,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2548,6 +2551,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1418,6 +1418,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "drucke"
 
@@ -2092,7 +2095,7 @@ msgstr "Benutzername"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2142,6 +2145,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -1521,6 +1521,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2255,7 +2258,7 @@ msgstr "Όνομα Χρήστη"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2306,6 +2309,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1294,6 +1294,9 @@ msgstr "Previous page"
 msgid "print_accounts"
 msgstr "Print"
 
+msgid "print_accounts_title"
+msgstr "Student accounts for hedy.org"
+
 msgid "print_logo"
 msgstr "print"
 
@@ -1906,7 +1909,7 @@ msgid "username"
 msgstr "Username"
 
 msgid "username_contains_invalid_symbol"
-msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following rows: {usernames}"
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 msgid "username_contains_separator"
 msgstr "Usernames cannot contain a semicolon. Perhaps you want to supply your own passwords? If so, click the passwords toggle and create the accounts again. If this is not the case, remove the semicolon from the following usernames: {usernames}"
@@ -1949,6 +1952,9 @@ msgstr "Waiting for submit"
 
 msgid "walker_variable_role"
 msgstr "walker"
+
+msgid "website"
+msgstr "Website"
 
 msgid "what_is_your_role"
 msgstr "What is your role?"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -1545,6 +1545,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "presu"
 
@@ -2262,7 +2265,7 @@ msgstr "Salutnomo"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2314,6 +2317,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1296,6 +1296,9 @@ msgstr "Página anterior"
 msgid "print_accounts"
 msgstr "Imprimir"
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "imprimir"
 
@@ -1952,6 +1955,9 @@ msgstr "Esperando para enviar"
 
 msgid "walker_variable_role"
 msgstr "caminante"
+
+msgid "website"
+msgstr ""
 
 msgid "what_is_your_role"
 msgstr "¿Cuál es tu papel?"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -1672,6 +1672,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "prindi"
 
@@ -2453,7 +2456,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2509,6 +2512,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -1686,6 +1686,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "سلام!"
 
@@ -2487,7 +2490,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2543,6 +2546,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -1677,6 +1677,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "tulosta"
 
@@ -2481,7 +2484,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2537,6 +2540,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -1447,6 +1447,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "affiche"
 
@@ -2123,7 +2126,7 @@ msgstr "Nom d'utilisateur"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2173,6 +2176,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/fr_CA/LC_MESSAGES/messages.po
+++ b/translations/fr_CA/LC_MESSAGES/messages.po
@@ -1682,6 +1682,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2540,6 +2543,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -1609,6 +1609,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2386,7 +2389,7 @@ msgstr "Brûkersnamme"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2439,6 +2442,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -1666,6 +1666,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "הדפס"
 
@@ -2447,7 +2450,7 @@ msgstr "שם משתמש"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2503,6 +2506,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -1545,6 +1545,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "प्रिंट"
 
@@ -2286,7 +2289,7 @@ msgstr "उपयोगकर्ता नाम"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2337,6 +2340,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/hr/LC_MESSAGES/messages.po
+++ b/translations/hr/LC_MESSAGES/messages.po
@@ -1683,6 +1683,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -1619,6 +1619,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "kiír"
 
@@ -2396,7 +2399,7 @@ msgstr "Felhasználónév"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2450,6 +2453,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -1678,6 +1678,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/iba/LC_MESSAGES/messages.po
+++ b/translations/iba/LC_MESSAGES/messages.po
@@ -1682,6 +1682,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2484,7 +2487,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2540,6 +2543,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1438,6 +1438,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "cetak"
 
@@ -2102,7 +2105,7 @@ msgstr "Nama Pengguna"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2152,6 +2155,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1635,6 +1635,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "stampa"
 
@@ -2417,7 +2420,7 @@ msgstr "Nome utente"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2471,6 +2474,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -1683,6 +1683,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "かけ"
 
@@ -2471,7 +2474,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2527,6 +2530,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -1677,6 +1677,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2482,7 +2485,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2538,6 +2541,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -1707,6 +1707,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2512,7 +2515,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2568,6 +2571,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -1679,6 +1679,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ms/LC_MESSAGES/messages.po
+++ b/translations/ms/LC_MESSAGES/messages.po
@@ -1682,6 +1682,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2484,7 +2487,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2540,6 +2543,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1520,6 +1520,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "skriv"
 
@@ -2234,7 +2237,7 @@ msgstr "Brukernavn"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2285,6 +2288,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ne/LC_MESSAGES/messages.po
+++ b/translations/ne/LC_MESSAGES/messages.po
@@ -1683,6 +1683,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -1391,6 +1391,9 @@ msgstr "Vorige pagina"
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2025,7 +2028,7 @@ msgstr "Gebruikersnaam"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2071,6 +2074,9 @@ msgstr "Wachten op indienen"
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -1675,6 +1675,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2478,7 +2481,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2534,6 +2537,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -1679,6 +1679,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/peo/LC_MESSAGES/messages.po
+++ b/translations/peo/LC_MESSAGES/messages.po
@@ -1682,6 +1682,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2484,7 +2487,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2540,6 +2543,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -1313,6 +1313,9 @@ msgstr "Poprzednia strona"
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "napisz"
 
@@ -1940,7 +1943,7 @@ msgstr "Nazwa użytkownika"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -1986,6 +1989,9 @@ msgstr "Oczekiwanie na przesłanie"
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1434,6 +1434,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "imprima"
 
@@ -2129,7 +2132,7 @@ msgstr "Usuário"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2179,6 +2182,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1434,6 +1434,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "imprimir"
 
@@ -2131,7 +2134,7 @@ msgstr "Utilizador"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2181,6 +2184,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -1674,6 +1674,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "printează"
 
@@ -2477,7 +2480,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2533,6 +2536,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -1453,6 +1453,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "печатать"
 
@@ -2132,7 +2135,7 @@ msgstr "Имя пользователя"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2182,6 +2185,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -1673,6 +1673,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2469,7 +2472,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2525,6 +2528,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -1676,6 +1676,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2480,7 +2483,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2536,6 +2539,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -1296,6 +1296,9 @@ msgstr "Претходна страница"
 msgid "print_accounts"
 msgstr "Штампај"
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "штампај"
 
@@ -1952,6 +1955,9 @@ msgstr "Чекање на подношење"
 
 msgid "walker_variable_role"
 msgstr "шетач"
+
+msgid "website"
+msgstr ""
 
 msgid "what_is_your_role"
 msgstr "Која је ваша улога?"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -1442,6 +1442,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "skriv"
 
@@ -2119,7 +2122,7 @@ msgstr "Användarnamn"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2169,6 +2172,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -1641,6 +1641,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2423,7 +2426,7 @@ msgstr "Jina la mtumiaji"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2477,6 +2480,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ta/LC_MESSAGES/messages.po
+++ b/translations/ta/LC_MESSAGES/messages.po
@@ -1679,6 +1679,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2477,7 +2480,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2532,6 +2535,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -1676,6 +1676,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "ముద్రణ"
 
@@ -2480,7 +2483,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2536,6 +2539,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -1651,6 +1651,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "แสดง"
 
@@ -2454,7 +2457,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2510,6 +2513,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -1677,6 +1677,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr ""
 
@@ -2482,7 +2485,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2538,6 +2541,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -1691,6 +1691,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "gatisa"
 
@@ -2495,7 +2498,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2551,6 +2554,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1407,6 +1407,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "yazdır"
 
@@ -2080,7 +2083,7 @@ msgstr "Kullanıcı Adı"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2130,6 +2133,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 msgid "what_is_your_role"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -1547,6 +1547,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "друкуй"
 
@@ -2318,7 +2321,7 @@ msgstr "Ім'я користувача"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2374,6 +2377,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -1676,6 +1676,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "دکھاؤ"
 
@@ -2480,7 +2483,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2536,6 +2539,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/uz/LC_MESSAGES/messages.po
+++ b/translations/uz/LC_MESSAGES/messages.po
@@ -1683,6 +1683,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 #, fuzzy
 msgid "print_logo"
 msgstr ""
@@ -2485,7 +2488,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2541,6 +2544,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -1668,6 +1668,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "xuất"
 
@@ -2468,7 +2471,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2524,6 +2527,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1305,6 +1305,9 @@ msgstr "上一页"
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "打印"
 
@@ -1925,7 +1928,7 @@ msgstr "用户名"
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -1971,6 +1974,9 @@ msgstr "等待提交"
 
 msgid "walker_variable_role"
 msgstr "漫游者"
+
+msgid "website"
+msgstr ""
 
 msgid "what_is_your_role"
 msgstr "你的角色是什么？"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -1675,6 +1675,9 @@ msgstr ""
 msgid "print_accounts"
 msgstr ""
 
+msgid "print_accounts_title"
+msgstr ""
+
 msgid "print_logo"
 msgstr "打印"
 
@@ -2479,7 +2482,7 @@ msgstr ""
 
 #, fuzzy
 msgid "username_contains_invalid_symbol"
-msgstr ""
+msgstr "Usernames cannot contain the symbol ':' or '@'. Remove these symbols from following usernames: {usernames}"
 
 #, fuzzy
 msgid "username_contains_separator"
@@ -2535,6 +2538,9 @@ msgstr ""
 
 #, fuzzy
 msgid "walker_variable_role"
+msgstr ""
+
+msgid "website"
 msgstr ""
 
 #, fuzzy

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -1328,7 +1328,7 @@ class ForTeachersModule(WebsiteModule):
             invalid_usernames = [usr for usr in lines if any(sym in usr for sym in invalid_symbols_in_username)]
             if invalid_usernames:
                 err = safe_format(gettext('username_contains_invalid_symbol'),
-                                  usernames=', '.join(usernames_with_separator))
+                                  usernames=', '.join(invalid_usernames))
                 return make_response({"error": err}, 400)
 
             accounts = [(user.lower(), utils.random_id_generator()) for user in lines]


### PR DESCRIPTION
This PR addresses the feedback for create student accounts in bulk feature.

Fixes #5886

**How to test**
- When a username contains forbidden characters `@` or `:`, the error message should point out the incorrect usernames.
- The font of the table containing the usernames and passwords should be with a monospace font, so that zero is different than a capital o.
- The height of the table that will be printed should be high, so that around 10 student accounts could fit in.