### PR TITLE
🧹 Remove the `awscli` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ ruamel.yaml==0.18.6
 docopt==0.6.2
 pydantic==1.10.13
 lazy==1.4
-awscli==1.32.77
 PySumTypes==0.0.1
 beautifulsoup4==4.9.3
 regex==2021.8.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ uflash>=2.0.0
 pyinstaller==6.3.0
 pylint==3.1.0
 commonmark==0.9.1
+colorama==0.4.6
 check-jsonschema


### PR DESCRIPTION
This dependency is causing some dependency installation problems on Windows, so get rid of it.

**How to test**

Hopefully this unblocks the Hedy Offline build when the next release comes around. If not, we'll dig deeper again with the error log that we have at that point.