### PR TITLE
🪲 Don't use `contents` when obtaining the contents of teacher adventures

### DIFF
--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -428,7 +428,7 @@ class ForTeachersModule(WebsiteModule):
                 content = adventure['content']
                 soup = BeautifulSoup(content, features="html.parser")
                 for pre in soup.find_all('pre'):
-                    adventure_snippets.append(str(pre.contents[0]))
+                    adventure_snippets.append(pre.text)
 
         student_code = program['code'].strip()
         # now we have to calculate the differences between the student code and the code snippets


### PR DESCRIPTION
Fixes the problem of the class overview page crashing when teacher adventures had HTML tags inside of them, by instead of calling `pre.contents[0]` using `pre.text`. This is mostly a fix for legacy adventures, since currently it is impossible to add an HTML tag inside a code snippet when creating a teacher adventure.

Fixes #5314 

**How to test**

Follow these steps to verify this PR works as intended:

 * Check that the class overview page works normally, even when students have programs from teacher adventures.
