### PR TITLE
🧹 Fix the if statement that prevents using conditions on Partition Keys

### DIFF
--- a/tests/test_dynamo.py
+++ b/tests/test_dynamo.py
@@ -690,6 +690,18 @@ class TestQueryInMemoryWithStringSortKey(unittest.TestCase, Helpers):
                 'id': dynamo.BeginsWith('k'),
             })
 
+    def test_may_not_use_condition_on_table_with_only_partition_key(self):
+        self.table = dynamo.Table(
+            dynamo.MemoryStorage(),
+            'table',
+            partition_key='id',
+        )
+
+        with self.assertRaises(ValueError):
+            self.table.get_many({
+                'id': dynamo.BeginsWith('k'),
+            })
+
     def test_can_disambiguate_between_indexes_with_same_pk(self):
         self.table = dynamo.Table(
             dynamo.MemoryStorage(),

--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -1632,7 +1632,9 @@ class CustomEncoder(json.JSONEncoder):
 def validate_only_sort_key(conds, sort_key):
     """Check that non-Equals conditions are only used on the sort key."""
     non_equals_fields = [k for k, v in conds.items() if not isinstance(v, Equals)]
-    if sort_key and set(non_equals_fields) - {sort_key}:
+    sort_key_set = {sort_key} if sort_key else set()
+
+    if set(non_equals_fields) - sort_key_set:
         raise ValueError(f"Non-Equals conditions only allowed on sort key {sort_key}, got: {list(conds)}")
 
 


### PR DESCRIPTION
This is a DynamoDB change that should have been in the previous PR, but failed to get committed.

It makes sure that in the one case where we have a table with only a PK, but no SK, the test that makes sure you only use `Condition`s on SKs works properly.

**How to test**

No need, it's been unit tested.