### PR TITLE
🚚 Install Heroku CLI on deploy action

### DIFF
--- a/.github/workflows/deploy-to-alpha.yml
+++ b/.github/workflows/deploy-to-alpha.yml
@@ -14,7 +14,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: 'Install Heroku CLI'
+        run: curl https://cli-assets.heroku.com/install.sh | sh
       - uses: akhileshns/heroku-deploy@v3.13.15 # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -11,7 +11,10 @@ jobs:
         run: |
           echo "You must be Felienne to run this workflow :D" >&2
           exit 1
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: 'Install Heroku CLI'
+        run: curl https://cli-assets.heroku.com/install.sh | sh
       - uses: akhileshns/heroku-deploy@v3.13.15 # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}


### PR DESCRIPTION
Github Actions have been updating their image from Ubuntu 22 to Ubuntu 24, and this action doesn't contain the Heroku CLI by default, so we have to install it before being able to run it.

More info: https://github.com/AkhileshNS/heroku-deploy/issues/184


**How to test**

* We'll have to approve the PR and test if the action works.

