### PR TITLE
🪲 Fix programs page redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -3158,7 +3158,7 @@ if __name__ == '__main__':
     debug = utils.is_debug_mode() and not (is_in_debugger or profile_memory)
     if debug:
         logger.debug('app starting in debug mode')
-
+    app_obj.add_url_rule("/", endpoint="index")
     # Threaded option enables multiple instances for multiple user access support
     app_obj.run(threaded=True, debug=debug,
                 port=config['port'], host="0.0.0.0")


### PR DESCRIPTION
Right now the programs page and my profile page is failing in Alpha. When looking at the logs this is what comes up:

```
werkzeug.routing.exceptions.BuildError: Could not build url for endpoint 'programs_page' with values ['page']. Did you mean 'app.programs_page' instead?
```

Investigating a bit, this might be caused because the url is not registered yet, like [here](https://stackoverflow.com/questions/51234212/werkzeug-routing-builderror-could-not-build-url-for-endpoint)