### PR TITLE
🪲 Fix keyword translation when keywords are substrings of each other

### DIFF
--- a/tests/test_translation_level/test_translation_level_06.py
+++ b/tests/test_translation_level/test_translation_level_06.py
@@ -114,3 +114,14 @@ class TestsTranslationLevel6(HedyTester):
             print a + 2""")
 
         self.verify_translation(code, "en", self.level)
+
+    def test_at_random_catalan(self):
+        """This used to fail because the Catalan translation of 'at' is 'a', which was a substring of 'at'."""
+
+        code = textwrap.dedent("""\
+            ruleta1 = ruleta at random
+            """)
+
+        result = hedy_translation.translate_keywords(code, from_lang="ca", to_lang="en", level=self.level)
+
+        self.assertEqual(result, 'ruleta1 = ruleta at random')


### PR DESCRIPTION
In #6118, we discovered that when the source language keywword is a substring of the target language keyword, we make a mistake in the string replacement.

This happens because we do the following:

- First: parse the entire program
- Then: for every line containing a keyword, do a separate search and replace on the line.

In this PR, I'm changing the logic a little: as part of parsing, we already know the location in the line where the keyword occurs, so we can just immediately replace that part of the line with the new keyword.

Two complications that make this slightly less straightforward than it sounds:

- Our grammar rules match whitespace as part of the keyword token, but the whitespace needs to remain in place.
    - Solution: find the whitespace in the matched token and only substitute the rest of the token.
- String substitutions may change the length of the string, and therefore invalidate all the indexes of the parse tree that follow it.
    - Solution: first collect a list of all subsitutions, then apply them in back-to-front order. That way, all yet-to-be-processed indexes are never disturbed by a substitution.

Fixes #6118.
