### PR TITLE
🪲 Cloned public adventure should retain original author

### DIFF
--- a/tests/python_html/fixtures/given.py
+++ b/tests/python_html/fixtures/given.py
@@ -61,27 +61,24 @@ class Given:
         self.db.store_user(teacher)
         return {'username': username, 'password': password}
 
-    def logged_in_as_student(self, username=None):
+    def logged_in_as_new_student(self, username=None):
         """Make sure that we are logged in."""
         user = self.a_student_account(username)
-
-        response = self.client.post('/auth/login', data=json.dumps({
-            'username': user['username'],
-            'password': user['password'],
-        }), content_type='application/json')
-        assert response.status_code == 200
+        self.logged_in_as(user)
         return user
 
-    def logged_in_as_teacher(self, username=None):
+    def logged_in_as_new_teacher(self, username=None):
         """Make sure that we are logged in as a teacher."""
         user = self.a_teacher_account(username)
+        self.logged_in_as(user)
+        return user
 
+    def logged_in_as(self, user):
         response = self.client.post('/auth/login', data=json.dumps({
             'username': user['username'],
             'password': user['password'],
         }), content_type='application/json')
         assert response.status_code == 200
-        return user
 
     def some_saved_program(self, username, **kwargs):
         """Save a program for the given user."""
@@ -98,6 +95,24 @@ class Given:
         }
         program.update(**kwargs)
         return self.db.store_program(program)
+
+    def some_saved_adventure(self, owner, level='1', **kwargs):
+        """Save an adventure for the given owner."""
+        adventure = {
+            "id": uuid.uuid4().hex,
+            "name": 'An adventure',
+            "content": 'Some adventure content',
+            "public": 0,
+            "creator": owner,
+            "author": owner,
+            "date": now_javascript(),
+            "level": level,
+            "levels": [level],
+            "language": 'en',
+            "is_teacher_adventure": True,
+        }
+        adventure.update(**kwargs)
+        return self.db.store_adventure(adventure)
 
 
 @pytest.fixture()

--- a/tests/python_html/test_explore.py
+++ b/tests/python_html/test_explore.py
@@ -7,7 +7,7 @@ import bs4
 def test_explore_page_loads_with_lots_of_programs(client: Client, given: Given):
     """Smoke test of the explore page, if there are enough programs for pagination."""
     # GIVEN
-    user = given.logged_in_as_student()
+    user = given.logged_in_as_new_student()
     for _ in range(50):
         given.some_saved_program(user['username'], public=1)
 

--- a/tests/python_html/test_login.py
+++ b/tests/python_html/test_login.py
@@ -32,7 +32,7 @@ def test_student_pages_protected(client: Client, endpoint):
 def test_student_pages_available(client: Client, given: Given, endpoint):
     """Check that these endpoints work if we are logged in as students."""
     # GIVEN
-    given.logged_in_as_student()
+    given.logged_in_as_new_student()
 
     # WHEN
     response = client.get(endpoint)

--- a/tests/python_html/test_programs.py
+++ b/tests/python_html/test_programs.py
@@ -6,7 +6,7 @@ from .fixtures.flask import Client
 def test_programs_page_loads_with_lots_of_programs(client: Client, given: Given):
     """Smoke test of the programs page, if there are enough programs for pagination."""
     # GIVEN
-    user = given.logged_in_as_student()
+    user = given.logged_in_as_new_student()
     for _ in range(20):
         given.some_saved_program(user['username'])
 

--- a/tests/python_html/test_public_adventures.py
+++ b/tests/python_html/test_public_adventures.py
@@ -1,0 +1,21 @@
+# https://werkzeug.palletsprojects.com/en/stable/test/
+from .fixtures.given import Given
+from .fixtures.flask import Client
+import pytest
+
+def test_cloning_public_adventure(client: Client, given: Given):
+    # GIVEN
+    t1 = given.a_teacher_account()
+    t2 = given.a_teacher_account()
+    t3 = given.a_teacher_account()
+    given.logged_in_as(t3)
+
+    # Adventure owned by t1, authored by t2
+    public_adv = given.some_saved_adventure(t1['username'], author=t2['username'], public=1)
+
+    # WHEN - t3 clones it
+    client.post(f'/public-adventures/clone/{public_adv["id"]}')
+
+    # THEN - now t3 owns an adventure still authored by t2
+    advs = given.db.get_teacher_adventures(t3['username'])
+    assert advs[0]['author'] == t2['username']

--- a/tests/python_html/test_public_adventures.py
+++ b/tests/python_html/test_public_adventures.py
@@ -3,6 +3,7 @@ from .fixtures.given import Given
 from .fixtures.flask import Client
 import pytest
 
+
 def test_cloning_public_adventure(client: Client, given: Given):
     # GIVEN
     t1 = given.a_teacher_account()

--- a/website/database.py
+++ b/website/database.py
@@ -187,8 +187,11 @@ class Database:
         # A custom teacher adventure
         # - id (str): id of the adventure
         # - content (str): adventure text
-        # - author (str): username (of a teacher account, hopefully)
-        # - creator (str): username (of a teacher account, hopefully)
+        # - creator (str): username (of a teacher account, hopefully). This originally was the person
+        #       who created and owned an adventure before we had cloning. Now that we have cloning, this
+        #       field is better understood as 'owner'.
+        # - author (str): username (of a teacher account, hopefully). If present, this is the person
+        #       who originally authored the adventure even throughout cloning.
         # - date (int): timestamp of last update (in milliseconds, JavaScript timestamp)
         # - level (str): level number, sometimes as an int, usually as a str
         # - levels: [str]: levels of the adventure
@@ -851,7 +854,7 @@ class Database:
 
     def store_adventure(self, adventure):
         """Store an adventure."""
-        self.adventures.create(adventure)
+        return self.adventures.create(adventure)
 
     def update_adventure(self, adventure_id, adventure):
         self.adventures.update({"id": adventure_id}, adventure)

--- a/website/public_adventures.py
+++ b/website/public_adventures.py
@@ -200,10 +200,10 @@ class PublicAdventuresModule(WebsiteModule):
             # Crucially, a cloned public adventure is not necessarily automatically public
             "public": 0,
 
-            # creator here is the new owner; we don't change it to owner because that'd introduce many conflicts.
-            # Instead handle it in html.
+            # 'creator' here means owner; we don't change the field name because that introduces too many conflicts.
+            # (Instead render it differently in HTML). The new owner is the current user.
             "creator": user["username"],
-            "author": current_adventure.get("creator"),
+            "author": current_adventure.get("author", current_adventure.get('creator')),
             "date": utils.timems(),
             "level": level,
             "levels": current_adventure.get("levels", [level]),


### PR DESCRIPTION
When an adventure with a two different people as `author` (original author) and `creator` (owner), we copied the owner into the original author field.

That's wrong -- the original author is the original author! 😉

Fix it, and add a unit test for it. Also document the values better.
