### PR TITLE
📜 Lock the slides Weblate component

### DIFF
--- a/.github/workflows/resolve-weblate-conflict.yml
+++ b/.github/workflows/resolve-weblate-conflict.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Prevent updates and merge conflicts until merged
       run: |
         # Have to lock each component individually. Not in the UI, but using the CLI we do.
-        for component in glossary adventures keywords client-messages web-texts webpages slides; do
+        for component in glossary adventures keywords client-messages web-texts webpages; do
           wlc lock hedy/$component
         done
 

--- a/.github/workflows/unlock-weblate.yml
+++ b/.github/workflows/unlock-weblate.yml
@@ -32,7 +32,7 @@ jobs:
     - run: |
         # Have to lock each component individually. Not in the UI, but using the CLI we do.
         set -x
-        for component in glossary adventures keywords client-messages web-texts webpages slides; do
+        for component in glossary adventures keywords client-messages web-texts webpages; do
           wlc --debug unlock hedy/$component | sed 's/${{ secrets.WEBLATE_API_KEY }}/*****/g'
         done
         echo "All components unlocked!"

--- a/.github/workflows/update-weblate.yml
+++ b/.github/workflows/update-weblate.yml
@@ -60,7 +60,7 @@ jobs:
 
         # Have to lock each component individually. Not in the UI, but using the CLI we do.
         # (NOTE: this list is also below!)
-        for component in glossary adventures keywords client-messages web-texts webpages slides; do
+        for component in glossary adventures keywords client-messages web-texts webpages; do
           wlc lock hedy/$component
         done
 
@@ -83,7 +83,7 @@ jobs:
 
           # Unlock each component again so we don't stay locked
           # (NOTE: this list is also above!)
-          for component in glossary adventures keywords client-messages web-texts webpages slides; do
+          for component in glossary adventures keywords client-messages web-texts webpages; do
             wlc unlock hedy/$component
           done
 


### PR DESCRIPTION
This PR removes the `slides` component from the scripts that lock/unlock Weblate components. The component should remain permanently locked until we update its structure.

Fixes  #6137

**How to test**
The component should be visible on Weblate, so that all contributors can see their work, but it should be locked.