### PR TITLE
🪲 fixes 6215 - introduces a new password generator that doesn't use characters that are easy to misread

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -312,6 +312,16 @@ def random_id_generator(
     return ''.join(random.choice(chars) for _ in range(size))
 
 
+def random_password_generator(size=6):
+    """
+    This function generates a random password using the base 58 characters to
+    prevent confusion between characters like 0 and O, or 1 and l.
+    """
+    base_58_chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+    return random_id_generator(size, base_58_chars)
+
+
+
 def markdown_to_html_tags(markdown):
     """
     This function takes a Markdown string and returns a list with each of the HTML elements obtained

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -1422,7 +1422,7 @@ class ForTeachersModule(WebsiteModule):
                                   usernames=', '.join(invalid_usernames))
                 return make_response({"error": err}, 400)
 
-            accounts = [(user.lower(), utils.random_id_generator()) for user in lines]
+            accounts = [(user.lower(), utils.random_password_generator()) for user in lines]
         else:
 
             accounts, incorrect_lines = self._extract_account_info(lines, separator)


### PR DESCRIPTION
We use a new random_password_generator function that uses a subset (base58) of the available characters to generate passwords. The reason for this change is that some characters are easy to misread, and this can lead to confusion.

**How to test**

Follow these steps to verify this PR works as intended:

* Invite new students to a group
* Print the generated passwords
* Confirm that none of the passwords contain the characters 0, O, l, and I

**Checklist**
Done? Check if you have it all in place using this list: (mark with x if done)

- [x ] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section
