### PR TITLE
💻 Put minimum quiz score behind a flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -1229,7 +1229,7 @@ def hour_of_code(level, program_id=None):
     # - The level is allowed and available
     # - But, if there is a quiz threshold we have to check again if the user has reached it
 
-    if 'level_thresholds' in customizations:
+    if not utils.is_redesign_enabled() and 'level_thresholds' in customizations:
         if 'quiz' in customizations.get('level_thresholds'):
             # Temporary store the threshold
             threshold = customizations.get('level_thresholds').get('quiz')
@@ -1402,7 +1402,7 @@ def index(level, program_id):
     # At this point we can have the following scenario:
     # - The level is allowed and available
     # - But, if there is a quiz threshold we have to check again if the user has reached it
-    if 'level_thresholds' in customizations:
+    if not utils.is_redesign_enabled() and 'level_thresholds' in customizations:
         # If quiz in level and in some of the previous levels, then we check the threshold level.
         check_threshold = 'other_settings' in customizations and 'hide_quiz' not in customizations['other_settings']
 


### PR DESCRIPTION
Removes the effect of the minimum quiz score set up by a teacher when the redesign flag is enabled.

Fixes #5989

**How to test**
Check that when the utils.is_redesign_enabled is set to True a student can see all levels regarding of whether they have completed a quiz for the previous level or not. Currently, in the local DB seeding, student1 cannot access levels above 13 and can be used for this test.
