### PR TITLE
🪲 Show submitted unmodified programs to teachers

### DIFF
--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -343,8 +343,7 @@ class ForTeachersModule(WebsiteModule):
                 adventures_tried += 1
                 name = adventure_names.get(program['adventure_name'], program['adventure_name'])
                 customized_level = class_adventures_formatted.get(str(program['level']))
-                if next((adventure for adventure in customized_level if adventure["name"] == name), False)\
-                        and program.get('is_modified'):
+                if next((adventure for adventure in customized_level if adventure["name"] == name), False):
                     student_adventure_id = f"{student}-{program['adventure_name']}-{level}"
                     current_adventure = self.db.student_adventure_by_id(student_adventure_id)
                     if not current_adventure:
@@ -606,20 +605,19 @@ class ForTeachersModule(WebsiteModule):
             date = utils.delta_timestamp(item['date'])
             # This way we only keep the first 4 lines to show as preview to the user
             preview_code = "\n".join(item['code'].split("\n")[:4])
-            if item.get('is_modified', True):
-                programs.append(
-                    {'id': item['id'],
-                     'preview_code': preview_code,
-                     'code': item['code'],
-                     'date': date,
-                     'level': item['level'],
-                     'name': item['name'],
-                     'adventure_name': item.get('adventure_name'),
-                     'submitted': item.get('submitted'),
-                     'public': item.get('public'),
-                     'number_lines': item['code'].count('\n') + 1
-                     }
-                )
+            programs.append(
+                {'id': item['id'],
+                 'preview_code': preview_code,
+                 'code': item['code'],
+                 'date': date,
+                 'level': item['level'],
+                 'name': item['name'],
+                 'adventure_name': item.get('adventure_name'),
+                 'submitted': item.get('submitted'),
+                 'public': item.get('public'),
+                 'number_lines': item['code'].count('\n') + 1
+                 }
+            )
         return jinja_partials.render_partial("incl/programs_loop.html",
                                              programs=programs,
                                              adventure_names=adventure_names,


### PR DESCRIPTION
The PR allows for displaying unmodified programs to teachers. Note that this PR focuses only on removing the situation in which a program is locked because it is handed in by a student and not visible by the teacher. This PR does not try to tell the teacher that the program is unmodified. This visualization will be done in the new teachers' interface.

Fixes #6311

**How to test**

Follow these steps to verify this PR works as intended:

- Log in as a student, who is enrolled in a class, and navigate to an adventure that has a working sample code (some levels have incomplete programs and you need a sample snippet that would just run without changes), e.g. Level 3, adventure Music. Paste the sample adventure code and execute it without changing it. Now hand in the program.
- Log in as the teacher of the class and check that the teacher can actually see the submitted program. It should appear in the "Student's Adventures" table and it should also appear in the "Class performance graph".

