### PR TITLE
🧹 Remove unused batchhedy deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,6 @@ bcrypt==3.2.0
 boto3>=1.16.50
 MarkupSafe==2.1.2
 ruamel.yaml==0.18.6
-docopt==0.6.2
-pydantic==1.10.21
-lazy==1.4
 PySumTypes==0.0.1
 beautifulsoup4==4.9.3
 regex==2021.8.28


### PR DESCRIPTION
`docopt`, `pydantic`, and `lazy` were added for `batchhedy` feature in
455037d061e7182230d8eea0084f36d59146ebbc, which had been unused and was
removed in c752db7365e5353488efca7d42760d53e585fafe

Issue: #3670
