### PR TITLE
🪲 Fix sorting of countries in signup and profile form

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ from safe_format import safe_format
 from config import config
 from website.flask_helpers import render_template, proper_tojson, JinjaCompatibleJsonProvider
 from hedy_content import (adventures_order_per_level, KEYWORDS_ADVENTURES, ALL_KEYWORD_LANGUAGES,
-                          ALL_LANGUAGES, COUNTRIES, HOUR_OF_CODE_ADVENTURES)
+                          ALL_LANGUAGES, COUNTRIES, FRIENDLY_SORTED_COUNTRIES, HOUR_OF_CODE_ADVENTURES)
 
 from logging_config import LOGGING_CONFIG
 from utils import dump_yaml_rt, is_debug_mode, load_yaml_rt, timems, version, strip_accents
@@ -2140,7 +2140,7 @@ def hedy_link(level_nr, assignment_nr, subpage=None):
 
 @app.app_template_global()
 def all_countries():
-    return COUNTRIES
+    return FRIENDLY_SORTED_COUNTRIES
 
 
 @app.app_template_global()

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -1,6 +1,8 @@
 import logging
 import os
 from os import path
+import iso3166
+from unidecode import unidecode
 
 import static_babel_content
 from utils import customize_babel_locale
@@ -10,6 +12,25 @@ from safe_format import safe_format
 logger = logging.getLogger(__name__)
 
 COUNTRIES = static_babel_content.COUNTRIES
+
+
+def _get_friendly_sorted_countries():
+    friendly_countries = []
+    for code, locale_name in COUNTRIES.items():
+        locale_name_starts_with_ascii = locale_name[0].isascii()
+        iso3166_english_name_normalized = unidecode(iso3166.countries.get(code).name).lower()
+        locale_name_normalized = unidecode(locale_name).lower()
+        if locale_name_starts_with_ascii or iso3166_english_name_normalized == locale_name_normalized:
+            friendly_countries.append((code, locale_name_normalized, locale_name))
+        else:
+            friendly_countries.append((code, iso3166_english_name_normalized, locale_name))
+
+    friendly_sorted_countries = sorted(friendly_countries, key=lambda c: c[1])
+
+    return list(map(lambda c: ((c[0], c[2])), friendly_sorted_countries))
+
+
+FRIENDLY_SORTED_COUNTRIES = _get_friendly_sorted_countries()
 
 MAX_LEVEL = 18
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ pyinstaller==6.11.1
 pylint==3.1.0
 commonmark==0.9.1
 colorama==0.4.6
-check-jsonschema
+check-jsonschema==0.28.4
+Unidecode==1.4.0

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -166,7 +166,7 @@
                 <label for="country" class="inline-block w-72">{{_('country')}}</label>
                 <select id="country" name="country" class="personal-input">
                     <option value="">{{_('select')}}</option>
-                    {% for alpha, name in all_countries().items() %}
+                    {% for alpha, name in all_countries() %}
                         <option value="{{ alpha }}" {% if alpha == user_data['country'] %}selected{% endif %}>{{ name }}</option>
                     {% endfor %}
                 </select>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -105,7 +105,7 @@
                     <label class="signup-label" for="country">{{_('country')}}</label>
                     <select class="signup-input appearance-none" id="country" data-cy="country" name="country">
                         <option value="" selected disabled hidden>{{_('select')}}</option>
-                        {% for alpha, name in all_countries().items() %}
+                        {% for alpha, name in all_countries() %}
                         <option value="{{ alpha }}">{{ name }}</option>
                         {% endfor %}
                     </select>


### PR DESCRIPTION
Fixes #6227 

* Sorts countries by their English names, with some heuristics to account for country names that are mostly in latin characters. Previously countries were effectively sorted by their country codes, which was confusing since the country codes often didn't match the spoken name.
* Adds a new exported `FRIENDLY_SORTED_COUNTRIES` constant to `hedy_content.py` which contains the statically sorted list of countries.
* Adds [Unidecode](https://pypi.org/project/Unidecode/) ([GitHub project](https://github.com/avian2/unidecode)) as a new dependency in `requirements.txt`. This allows better sorting of names that have unicode characters or characters with diacritics.
* Changes `signup.html` and `profile.html` to use `all_countries()` instead of `all_countries().items()`, since it is now a list, not a dict.
* Also added a version number to `check-jsonschema` in `requirements.txt`, for consistency. The version is based on the git blame date, when the dependency was added.

**How to test**

Follow these steps to verify this PR works as intended:

* Go to http://localhost:8080/signup?teacher=false
* See that the countries are sorted more reasonably. e.g. "Nederland" is sorted above "Nicaragua", and "South Africa" is not at the bottom of the list

**Checklist**
Done? Check if you have it all in place using this list: (mark with x if done)

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section