### PR TITLE
💻 Add Facebook and LinkedIn links to website footer

### DIFF
--- a/templates/main-page.html
+++ b/templates/main-page.html
@@ -78,6 +78,8 @@
             </div>
             <div class="flex-1">
                 <a href="https://github.com/hedyorg/hedy" data-cy="github_button">{{_('hedy_on_github')}}</a><br>
+                <a href="https://www.facebook.com/profile.php?id=61578101102215" data-cy="facebook_button">{{_('facebook_page')}}</a><br>
+                <a href="https://www.linkedin.com/company/hedyorg" data-cy="linkedin_button">{{_('linkedin_page')}}</a><br>
                 <a href="https://github.com/sponsors/hedyorg" data-cy="sponsor_button">{{_('become_a_sponsor')}}</a><br>
                 <a href="https://discord.gg/8yY7dEme9r" data-cy="discord_button">{{_('discord_server')}}</a><br>
                 <a href="https://github.com/hedyorg/hedy/wiki/Hedy-Translation-Tutorial" data-cy="translate_button">{{_('translating_hedy')}}</a><br>

--- a/tests/cypress/e2e/home_page/footer_buttons.cy.js
+++ b/tests/cypress/e2e/home_page/footer_buttons.cy.js
@@ -8,6 +8,8 @@ it('Is able to click on all footer buttons', () => {
     // I am not sure how to check a redirect to an external page
     goToHome();
     cy.getDataCy('github_button').should('be.visible')
+    cy.getDataCy('facebook_button').should('be.visible')
+    cy.getDataCy('linkedin_button').should('be.visible')
     cy.getDataCy('sponsor_button').should('be.visible')
     cy.getDataCy('discord_button').should('be.visible')
     cy.getDataCy('translate_button').should('be.visible')

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -699,6 +699,9 @@ msgstr "الرجاء اختيار الخبرة بشكل صحيح (نعم ، لا
 msgid "expiration_date"
 msgstr "تاريخ انتهاء الصلاحية"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -985,6 +988,9 @@ msgstr ""
 
 msgid "link"
 msgstr "الرابط"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "قائمة"

--- a/translations/be/LC_MESSAGES/messages.po
+++ b/translations/be/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -750,6 +750,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1065,6 +1068,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1098,6 +1101,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/brx/LC_MESSAGES/messages.po
+++ b/translations/brx/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "Si us plau, selecciona una experiència vàlida, escull (Sí, No)."
 msgid "expiration_date"
 msgstr "Data de caducitat"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Programa preferit"
 
@@ -838,6 +841,9 @@ msgstr "nivells"
 
 msgid "link"
 msgstr "Enllaç"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "una llista"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -753,6 +753,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1068,6 +1071,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Přihlásit se"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1098,6 +1101,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -762,6 +762,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1085,6 +1088,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -662,6 +662,9 @@ msgstr "Bitte wähle eine gültige Erfahrung, nutze (Ja, Nein)."
 msgid "expiration_date"
 msgstr "Ablaufdatum"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Lieblingsprogramm"
 
@@ -926,6 +929,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -713,6 +713,9 @@ msgstr "Παρακαλώ διάλεξε μια έγκυρη εμπειρία, ε
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1002,6 +1005,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Σύνδεση"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "μια λίστα"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -591,6 +591,9 @@ msgstr "Please select a valid experience, choose (Yes, No)."
 msgid "expiration_date"
 msgstr "Expiration date"
 
+msgid "facebook_page"
+msgstr "Hedy on Facebook"
+
 msgid "favorite_program"
 msgstr "Favorite program"
 
@@ -836,6 +839,9 @@ msgstr "levels"
 
 msgid "link"
 msgstr "Link"
+
+msgid "linkedin_page"
+msgstr "Hedy on LinkedIn"
 
 msgid "list"
 msgstr "a list"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -720,6 +720,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr "Dato de eksvalidiĝo"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1016,6 +1019,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Ligo"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "listo"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "Por favor, selecciona una experiencia válida. Escoge (sí, no)."
 msgid "expiration_date"
 msgstr "Fecha de expiración"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Programa favorito"
 
@@ -838,6 +841,9 @@ msgstr "niveles"
 
 msgid "link"
 msgstr "Enlace"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "una lista"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -771,6 +771,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1089,6 +1092,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1097,6 +1100,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -683,6 +683,9 @@ msgstr "Sélectionnez une expérience valide, choisissez (Oui, Non)."
 msgid "expiration_date"
 msgstr "Date d'expiration"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -955,6 +958,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Lien"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "une liste"

--- a/translations/fr_CA/LC_MESSAGES/messages.po
+++ b/translations/fr_CA/LC_MESSAGES/messages.po
@@ -777,6 +777,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1100,6 +1103,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -743,6 +743,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1056,6 +1059,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Log yn"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/ga/LC_MESSAGES/messages.po
+++ b/translations/ga/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -764,6 +764,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1082,6 +1085,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -718,6 +718,9 @@ msgstr "कृपया एक मान्य अनुभव चुनें, 
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1010,6 +1013,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "लॉगिन"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "एक सूची"

--- a/translations/hr/LC_MESSAGES/messages.po
+++ b/translations/hr/LC_MESSAGES/messages.po
@@ -778,6 +778,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1101,6 +1104,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -746,6 +746,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1058,6 +1061,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Belépés"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1098,6 +1101,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/iba/LC_MESSAGES/messages.po
+++ b/translations/iba/LC_MESSAGES/messages.po
@@ -777,6 +777,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1100,6 +1103,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -689,6 +689,9 @@ msgstr "Silakan pilih pengalaman yang valid, pilih (Ya, Tidak)."
 msgid "expiration_date"
 msgstr "Tanggal habis tempo"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Program favorit"
 
@@ -948,6 +951,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Tautan"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "daftar"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -747,6 +747,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1064,6 +1067,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Accedi"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1095,6 +1098,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/jbo/LC_MESSAGES/messages.po
+++ b/translations/jbo/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/kab/LC_MESSAGES/messages.po
+++ b/translations/kab/LC_MESSAGES/messages.po
@@ -653,6 +653,9 @@ msgstr "Ttxil-k fren tirmit tameɣtut, fren (Ih, Ala)."
 msgid "expiration_date"
 msgstr "Azemz n keffu"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Ahil asmenyaf"
 
@@ -917,6 +920,9 @@ msgstr "Iswiren"
 
 msgid "link"
 msgstr "Aseɣwen"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "tabdart"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1097,6 +1100,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/kn/LC_MESSAGES/messages.po
+++ b/translations/kn/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr "올바른 경험을 선택하고 (예, 아니오)를 선택하십시오.
 msgid "expiration_date"
 msgstr "만료기한"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr "좋아하는 프로그램"
@@ -1099,6 +1102,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "링크"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/lt/LC_MESSAGES/messages.po
+++ b/translations/lt/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1098,6 +1101,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/ml/LC_MESSAGES/messages.po
+++ b/translations/ml/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/mr/LC_MESSAGES/messages.po
+++ b/translations/mr/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/ms/LC_MESSAGES/messages.po
+++ b/translations/ms/LC_MESSAGES/messages.po
@@ -777,6 +777,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1100,6 +1103,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/my/LC_MESSAGES/messages.po
+++ b/translations/my/LC_MESSAGES/messages.po
@@ -590,6 +590,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr ""
 
@@ -834,6 +837,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -712,6 +712,9 @@ msgstr "Vennligst velg svar på spørsmål om programmeringserfaring (Ja/Nei)."
 msgid "expiration_date"
 msgstr "Utløpsdato"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1001,6 +1004,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Logg inn"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "en liste"

--- a/translations/ne/LC_MESSAGES/messages.po
+++ b/translations/ne/LC_MESSAGES/messages.po
@@ -778,6 +778,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1101,6 +1104,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -649,6 +649,9 @@ msgstr "Dit is geen geldige programmeerervaring, kies uit (Ja, Nee)."
 msgid "expiration_date"
 msgstr "Vervaldatum"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Favoriete programma"
 
@@ -903,6 +906,9 @@ msgid "levels"
 msgstr ""
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -775,6 +775,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1098,6 +1101,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/peo/LC_MESSAGES/messages.po
+++ b/translations/peo/LC_MESSAGES/messages.po
@@ -777,6 +777,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1100,6 +1103,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -603,6 +603,9 @@ msgstr "Proszę wybrać poprawne doświadczenie, wybierz (Tak, Nie)."
 msgid "expiration_date"
 msgstr "Data wygaśnięcia"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Ulubiony program"
 
@@ -848,6 +851,9 @@ msgid "levels"
 msgstr "Poziomy"
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -657,6 +657,9 @@ msgstr "Por favor, selecione uma experiência válida. Escolha (Sim, Não)."
 msgid "expiration_date"
 msgstr "Data de expiração"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Programa favorito"
 
@@ -922,6 +925,9 @@ msgid "levels"
 msgstr "níveis"
 
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 msgid "list"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -674,6 +674,9 @@ msgstr "Por favor, selecione uma experiência válida. Escolha (Sim, Não)."
 msgid "expiration_date"
 msgstr "Data de expiração"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Programa favorito"
 
@@ -940,6 +943,9 @@ msgstr "níveis"
 
 msgid "link"
 msgstr "Ligação"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "uma lista"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -686,6 +686,9 @@ msgstr "Пожалуйста, выберите действующий опыт, 
 msgid "expiration_date"
 msgstr "Срок действия"
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -960,6 +963,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Ссылка"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "список"

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -773,6 +773,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1086,6 +1089,9 @@ msgstr "stopnje"
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "Молимо вас да изаберете важеће искуств�
 msgid "expiration_date"
 msgstr "Датум истека"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Омиљени програм"
 
@@ -838,6 +841,9 @@ msgstr "нивои"
 
 msgid "link"
 msgstr "Веза"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "листа"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -680,6 +680,9 @@ msgstr "Välj en giltig erfarenhet, alltså (Ja, Nej)."
 msgid "expiration_date"
 msgstr "Förfallodatum"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Favoritprogram"
 
@@ -950,6 +953,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Länk"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "en lista"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -755,6 +755,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1071,6 +1074,9 @@ msgstr ""
 #, fuzzy
 msgid "link"
 msgstr "Login"
+
+msgid "linkedin_page"
+msgstr ""
 
 #, fuzzy
 msgid "list"

--- a/translations/ta/LC_MESSAGES/messages.po
+++ b/translations/ta/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "சரியான பட்டறிவைத் தேர்ந்த�
 msgid "expiration_date"
 msgstr "காலாவதி தேதி"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "பிடித்த நிரல்"
 
@@ -838,6 +841,9 @@ msgstr "நிலைகள்"
 
 msgid "link"
 msgstr "இணைப்பு"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "ஒரு பட்டியல்"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1077,6 +1080,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -614,6 +614,9 @@ msgstr "Lütfen geçerli bir deneyim seçin, (Evet, Hayır) seçeneğini işaret
 msgid "expiration_date"
 msgstr "Son kullanma tarihi"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Favori program"
 
@@ -874,6 +877,9 @@ msgstr ""
 
 msgid "link"
 msgstr "Bağlantı"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "bir liste"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "Виберіть дійсний досвід, виберіть (Так, 
 msgid "expiration_date"
 msgstr "Термін придатності"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "Улюблена програма"
 
@@ -838,6 +841,9 @@ msgstr "рівнях"
 
 msgid "link"
 msgstr "Посилання"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "список"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -774,6 +774,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1096,6 +1099,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/uz/LC_MESSAGES/messages.po
+++ b/translations/uz/LC_MESSAGES/messages.po
@@ -778,6 +778,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1101,6 +1104,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -768,6 +768,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1090,6 +1093,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -593,6 +593,9 @@ msgstr "请选择有效的经验，选择（是，否）。"
 msgid "expiration_date"
 msgstr "过期日期"
 
+msgid "facebook_page"
+msgstr ""
+
 msgid "favorite_program"
 msgstr "最喜欢的项目"
 
@@ -838,6 +841,9 @@ msgstr "关卡"
 
 msgid "link"
 msgstr "链接"
+
+msgid "linkedin_page"
+msgstr ""
 
 msgid "list"
 msgstr "列表"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -773,6 +773,9 @@ msgstr ""
 msgid "expiration_date"
 msgstr ""
 
+msgid "facebook_page"
+msgstr ""
+
 #, fuzzy
 msgid "favorite_program"
 msgstr ""
@@ -1095,6 +1098,9 @@ msgstr ""
 
 #, fuzzy
 msgid "link"
+msgstr ""
+
+msgid "linkedin_page"
 msgstr ""
 
 #, fuzzy


### PR DESCRIPTION
**Description**
Added Facebook and LinkedIn links to the website footer

**How to test**
Follow these steps to verify this PR works as intended:

* Open the Hedy website locally (http://127.0.0.1:5000).
* Scroll to the footer section of the main page. (http://127.0.0.1:5000)
* Confirm that Facebook and LinkedIn links are present. ("Hedy on Facebook" "Hedy on LinkedIn")
* Click each link to verify they redirect to the correct Hedy page.

**Checklist**

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [ ] Links to an existing issue or discussion
- [x] Has a "How to test" section
