### PR TITLE
Footer mobile fix

### DIFF
--- a/templates/main-page.html
+++ b/templates/main-page.html
@@ -68,8 +68,8 @@
         </div>
         {% endfor %}
     </div>
-    <div class="bg-pink-800 text-sm text-white py-16">
-        <div class="flex w-100 max-w-screen-md mx-auto text-links-plain">
+    <div class="bg-pink-800 text-base text-white py-16">
+        <div class="flex flex-col sm:flex-row max-w-screen-md mx-auto text-center text-links-plain">
             <div class="flex-1">
                 <a href="/subscribe" data-cy="subscribe_button">{{_('subscribe_newsletter')}}</a><br>
                 <a href="/learn-more" data-cy="learnmore_button">{{_('nav_learn_more')}}</a><br>

--- a/templates/main-page.html
+++ b/templates/main-page.html
@@ -69,7 +69,7 @@
         {% endfor %}
     </div>
     <div class="bg-pink-800 text-base text-white py-16">
-        <div class="flex flex-col sm:flex-row max-w-screen-md mx-auto text-center text-links-plain">
+        <div class="flex flex-col sm:flex-row max-w-screen-md mx-auto px-10 text-links-plain">
             <div class="flex-1">
                 <a href="/subscribe" data-cy="subscribe_button">{{_('subscribe_newsletter')}}</a><br>
                 <a href="/learn-more" data-cy="learnmore_button">{{_('nav_learn_more')}}</a><br>


### PR DESCRIPTION
#5381

**Description**
* On mobile, the footer now stacks items vertically.
* On larger screens, items remain side by side but text is centered.
* Font size has been increased slightly to make the text easier to read.

**How to test**
Follow these steps to verify this PR works as intended:
* Pull this branch and run Hedy locally (http://localhost:5000).
* Resize the window to a mobile width (<768px). Tip: In Chrome/Edge, right-click the page, choose Inspect, then toggle the device toolbar and select a device like Pixel 7. 
  * Footer content should stack vertically.
  * Text should be centered horizontally.
  * Font size should be larger than before.
* Resize the window to a larger screen (>768px).
  * The footer content should be in two columns.
  * Text should still be centered vertically and horizontally.

**Checklist**

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section