### PR TITLE
💻Allows email addresses as usernames when student account is cre…

### DIFF
--- a/website/auth_pages.py
+++ b/website/auth_pages.py
@@ -56,6 +56,9 @@ class AuthModule(WebsiteModule):
         # If username has an @-sign, then it's an email
         if "@" in body["username"]:
             user = self.db.user_by_email(body["username"])
+            # If not found, it may be email as username (possible for accounts created by teachers)
+            if not user:
+                user = self.db.user_by_username(body["username"])
         else:
             user = self.db.user_by_username(body["username"])
 
@@ -384,6 +387,9 @@ class AuthModule(WebsiteModule):
         # If username has an @-sign, then it's an email
         if "@" in body["username"]:
             user = self.db.user_by_email(body["username"].strip().lower())
+            # If not found, it may be email as username (possible for accounts created by teachers)
+            if not user:
+                user = self.db.user_by_username(body["username"])
         else:
             user = self.db.user_by_username(body["username"].strip().lower())
 

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -1300,8 +1300,8 @@ class ForTeachersModule(WebsiteModule):
                 err = safe_format(gettext('username_contains_separator'), usernames=', '.join(usernames_with_separator))
                 return make_response({"error": err}, 400)
 
-            # Currently usernames cannot contain '@' and ':'
-            invalid_symbols_in_username = ['@', ':']
+            # Currently usernames cannot contain ':'. The original reason for this is unknown
+            invalid_symbols_in_username = [':']
             invalid_usernames = [usr for usr in lines if any(sym in usr for sym in invalid_symbols_in_username)]
             if invalid_usernames:
                 err = safe_format(gettext('username_contains_invalid_symbol'),
@@ -1361,7 +1361,7 @@ class ForTeachersModule(WebsiteModule):
         for usr, pwd in accounts:
             # Set the current teacher language and keyword language as new account language
             user = {'username': usr, 'password': pwd, 'language': g.lang, 'keyword_language': g.keyword_lang}
-            store_new_student_account(self.db, user, teacher)
+            print("CREATED_USER: ", store_new_student_account(self.db, user, teacher))
             self.db.add_student_to_class(body["class"], usr)
         response = {"accounts": [{"username": usr, "password": pwd} for usr, pwd in accounts]}
         return make_response(response, 200)


### PR DESCRIPTION
Allows email addresses as usernames when student account is created by teacher.
The colon character (:) is still disallowed. The original reason for disallowing this was not found, and it was decided that there was not enough demand for allowing it to warrent the effort.

Fixes #5888
**How to test**

Follow these steps to verify this PR works as intended:

* Create a teacher account
* Create a class
* Click "Add students" and "Create accounts"
* Create one or more student accounts containing an "@"
* Verify that you can log into those new student accounts

**Checklist**
Done? Check if you have it all in place using this list: (mark with x if done)

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [x] Links to an existing issue or discussion
- [x] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
