### PR TITLE
🚚 Make offline build use Python 3.10

### DIFF
--- a/.github/workflows/build-offline.yml
+++ b/.github/workflows/build-offline.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
         cache: 'pip'
     - name: Set up NodeJS 18
       uses: actions/setup-node@v3


### PR DESCRIPTION
Hedy is now using the `|` symbol in type hints to indicate type unions, which is Python 3.10+ syntax. The offline build was still using Python 3.9, so it failed.

Change it to Python 3.10 as well.

**How to test**

Merge and see if the offline build succeeds if we run it on-demand.