### PR TITLE
🚚 Actually select Python 3.10 in the offline build

### DIFF
--- a/.github/workflows/build-offline.yml
+++ b/.github/workflows/build-offline.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: 'pip'
     - name: Set up NodeJS 18
       uses: actions/setup-node@v3


### PR DESCRIPTION
In `python-version: 3.10`, the version gets interpreted as a number.

We don't end up installing Python 3.10, but Python 3.1.

That's not what I wanted! 🤬

Change to

```
python-version: '3.10'
```

instead

**How to test**

Merge and run workflow and cross fingers