### PR TITLE
Fix creation of accounts for class in Catalan

### DIFF
--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -444,7 +444,7 @@ msgid "create_accounts_placeholder"
 msgstr "Escriviu els comptes o enganxeu-los des d'un full de càlcul"
 
 msgid "create_accounts_prompt"
-msgstr "Crearàs {number_of_accounts} comptes d'estudiant. Estàs segur?"
+msgstr "Crearàs {number_of_accounts} comptes d\'estudiant. Estàs segur?"
 
 msgid "create_adventure"
 msgstr "Crear aventura"


### PR DESCRIPTION
A teacher reported to us that creating accounts in a class was failing for him. After further investigation, I discovered that the issue was caused because the translation contains a ' which colidded with the html code and caused an error. Fixing it for the general case was taking me too much time, so here Im just fixing it for this case, but in the future I want to work on a way that actually solves this problem in general.


**How to test**

1. Log in as a teacher and set your language to Catalan.
2. Go to the create acount secctions of the class
3. When clicking  on Create accounts it should work

!
