### PR TITLE
* 🪲 -> Fix bug in Catalan translation message in messages.po that breaks unsubmit button

### DIFF
--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -1840,7 +1840,7 @@ msgid "unsubmit_program"
 msgstr "Desfés l'enviament del programa"
 
 msgid "unsubmit_warning"
-msgstr "Estàs segur que vols desfer la tramesa d'aquest programa?"
+msgstr "Estàs segur que vols desfer la tramesa del programa?"
 
 msgid "unsubmitted"
 msgstr "No enviat"


### PR DESCRIPTION
- Fixes #6409 
- Removes the apostrophe character (also single quotation mark) that breaks frontend JavaScript.

**How to test**

Follow these steps to verify this PR works as intended:

* Change the display language to Catalan
* Go to a student submission and try to unsubmit (Desfés l'enviament).  
* If the confirmation modal appears, the bug is solved.

