### PR TITLE
 💻 Fix typo in error_text for variable example (uitveor -> uitvoer)

### DIFF
--- a/content/pages/nl.yaml
+++ b/content/pages/nl.yaml
@@ -423,7 +423,7 @@ teacher-guide:
                     eten {is} {ask} 'Wat wil je bestellen?'
         -   title: Leerlingen gebruiken hoge komma's na een print commando
             example:
-                error_text: Een hoge komma kan je niet gebruiken in een print commando. Je ziet het al aan de verkeerde verkeuring in de tekst.
+                error_text: Een hoge komma kan je niet gebruiken in een print commando. Je ziet het al aan de verkeerde verkleuring in de tekst.
                 error_code: "{print} 'Er lopen twee oma's door het park'"
                 solution_text: Je kunt ervoor kiezen om het woord fout te spellen door geen hoge komma te gebruiken, of je kunt de schuine komma gebruiken. Die zit linksboven naast de 1 toets op je toetsenbord.
                 solution_code: |-


### PR DESCRIPTION
Changed “uitveor” to “uitvoer"
