### PR TITLE
💻 Slides restyled

### DIFF
--- a/static/vendor/reveal/dist/theme/sky.css
+++ b/static/vendor/reveal/dist/theme/sky.css
@@ -28,7 +28,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   --r-heading-color: #2B6CB0;
   --r-heading-line-height: 1.2;
   --r-heading-text-shadow: none;
-  --r-heading-font-weight: 700;
+  --r-heading-font-weight: normal;
   --r-heading1-text-shadow: none;
   --r-heading1-size: 3.77em;
   --r-heading2-size: 2.11em;


### PR DESCRIPTION
Fixes #6437 

- Slide headings fonts changed to balsamiq sans (bold)
- Gradient background changed


**How to test**

- Go to any teacher slides page (e.g., http://localhost:8080/slides/2#/2)
- Verify that the headings display in blue with the Balsamiq Sans font
- Verify that the body text is readable in black
- Verify that the background displays a subtle gradient
- Check that slides render correctly on different screen sizes

**New**:
<img width="1708" height="669" alt="image" src="https://github.com/user-attachments/assets/16954b70-e3df-42bc-b9c2-a3660055f0f6" />


**Old:** 
<img width="1708" height="669" alt="image" src="https://github.com/user-attachments/assets/3dd1462a-b3ab-4c82-ae60-e66bbcf97216" />