### PR TITLE
Fix yellow arrow direction issue #6501

### DIFF
--- a/templates/class-overview.html
+++ b/templates/class-overview.html
@@ -4,7 +4,7 @@
 <div>
     <div class="flex flex-col gap-4">
         <button class="back-btn" id="go_back_button" data-cy="go_back_button" onclick="window.location.href = '/for-teachers'">
-            <span class="fa fa-arrow-{% if g.dir == " ltr" %}right{% else %}left{% endif %}">&nbsp;</span>
+            <span class="fa fa-arrow-down">&nbsp;</span>
             {{_('go_back')}}
         </button>
         {% if second_teacher %}<h1>{{_('role')}}: {{role}}</h1>{% endif %}

--- a/templates/create-accounts.html
+++ b/templates/create-accounts.html
@@ -3,7 +3,7 @@
 {% block regular_content %}
 <div>
     <button class="back-btn" id="go_back_button" data-cy="go_back_button" onclick="window.open('/for-teachers/class/{{ current_class.id }}', '_self');">
-        <span class="fa fa-arrow-{% if g.dir == "ltr" %}left{% else %}right{% endif %}">&nbsp;</span>
+        <span class="fa fa-arrow-down">&nbsp;</span>
         {{_('go_back')}}
     </button>
     <h2 id="create_accounts_title">{{_('create_student_accounts')}} {{current_class.name}}</h2>

--- a/templates/customize-adventure.html
+++ b/templates/customize-adventure.html
@@ -3,7 +3,7 @@
 {% block regular_content %}
 <button id='go_back_button' data-cy='go_back_button' class="back-btn"
 onclick="window.open('/for-teachers', '_self');">
-    <span class="fa fa-arrow-{% if g.dir == "ltr" %}left{% else %}right{% endif %}">&nbsp;</span>
+    <span class="fa fa-arrow-down">&nbsp;</span>
     <span>{{_('go_back')}}</span>
 </button>
 <br><br>

--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -1,7 +1,7 @@
 {% extends "auth.html" %}
 {% block regular_content %}
 <button id="back_to_class" class="back-btn" data-cy="back_to_class">
-    <span class="fa fa-arrow-{% if g.dir == "ltr" %}left{% else %}right{% endif %}">&nbsp;</span>
+    <span class="fa fa-arrow-down">&nbsp;</span>
     <span>{{_('go_back')}}</span>
 </button>
 <br><br>


### PR DESCRIPTION
## 📝 Description

This PR fixes issue #6501: "Change the yellow button"

The yellow arrow is pointing to the side which does not make that much sense, especially in Arabic (RTL) layouts. As described in the issue, we need to make it point downwards to the editor and use Font Awesome's arrow-down icon.

## 🔧 Changes Made

Changed all occurrences of conditional left/right arrows to downward-pointing arrows in 4 template files:

1. **templates/class-overview.html** - Back button arrow
2. **templates/create-accounts.html** - Back button arrow
3. **templates/customize-adventure.html** - Back button arrow
4. **templates/customize-class.html** - Back button arrow

**Before:**
```html
<span class="fa fa-arrow-{% if g.dir == "ltr" %}left{% else %}right{% endif %}">&nbsp;</span>
```

**After:**
```html
<span class="fa fa-arrow-down">&nbsp;</span>
```

## ✅ Benefits

1. **RTL-friendly**: Downward arrow makes sense in all language directions (LTR/RTL)
2. **Clear direction**: Points toward the editor/content as intended
3. **Simplified code**: Removes conditional logic for language direction
4. **Uses Font Awesome**: As requested in the issue description

## 🧪 Testing

- The change is purely visual and does not affect functionality
- Should work correctly in both LTR and RTL layouts
- Maintains accessibility and semantic meaning

## 📋 Issue Reference

Closes #6501

---

This is a good first issue/tiny hackathon issue as labeled.