### PR TITLE
🪲 Fix Hedy Offline build by upgrading build to Python 3.12

### DIFF
--- a/.github/workflows/build-offline.yml
+++ b/.github/workflows/build-offline.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: 'pip'
     - name: Set up NodeJS 18
       uses: actions/setup-node@v3


### PR DESCRIPTION
Offline build was unsuccessful due to usage of "\n" in f-strings (lines 2771 and 2775 of `hedy/__init__.py`), which was not allowed in Python 3.10.

In Python 3.12+ this is allowed, so this upgrade should fix it.

Fixes (no existing issue).

**How to test**

Follow these steps to verify this PR works as intended:

* Manually run `Build offline Hedy` workflow to see build is now successful.

**Checklist**
Done? Check if you have it all in place using this list: (mark with x if done)

- [x] Contains one of the PR categories in the name
- [x] Describes changes in the format above
- [ ] Links to an existing issue or discussion
- [x] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
