### PR TITLE
🚚 fix: Codespaces container fails to build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN npm ci
 FROM main
 
 # Setup python packages
-COPY requirements.txt /tmp/requirements.txt
+COPY requirements.txt equirements-prod.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy node modules to a tmp folder

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libgtk-3-0 \
     libgbm-dev \
     libnotify-dev \
-    libgconf-2-4 \
     libnss3 \
     libxss1 \
     libasound2 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN npm ci
 FROM main
 
 # Setup python packages
-COPY requirements.txt equirements-prod.txt /tmp/requirements.txt
+COPY requirements.txt requirements-prod.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy node modules to a tmp folder

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,8 @@ FROM main
 
 # Setup python packages
 COPY requirements.txt requirements-prod.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt \
+    && pip3 install --no-cache-dir pre-commit
 
 # Copy node modules to a tmp folder
 COPY --from=node_builder /app/node_modules /var/tmp/node_modules


### PR DESCRIPTION
**Problem**
When starting a Codespace as described in https://github.com/hedyorg/hedy/wiki/Hedy-Development-Process
the devcontainer fails.

**Applied fixes**
Based on interpretation of the logfile (errors) and some help of AI, I subsequently made the following changes:
1. Remove libgconf-2-4 from Dockerfile dependencies, as this package did not install (AI says that it's an old package which is removed from the distribution)
2. Add requirements-prod file to copy in Dockerfile, to prevent abortion during installing packages from requirements.txt (which depends on requirements-prod.txt)
3. Add pre-commit installation to Dockerfile, to prevent `create.sh` to abort

Number 1. is a bit tricky, as it might break other things in de Codespace. However, as far as I could see (see How to test below), it works as desired. And if it does break things, it will not get worse, as Codespaces doesn't start at all without this fix.

**How to test**
Follow these steps to verify this PR works as intended:
1. create a Codespace 
2. start Hedy with the terminal command `python3 app.py`
3. check if Hedy works
4. change some code of Hedy
5. recompile (I guess) and restart Hedy
6. check if Hedy works

I tested step 1,2 and 3. I did not test step 4, 5, 6 (due to a personal lack of knowledge)

**Remark for review**
I can imagine that it would be better to update the Codespace configuration in such a way that is more in line with other configurations, for example by sharing a single Dockerfile. This PR doesn't do that. This PR does fix the Codespace configuration, so for now it may be considered as a step in the right direction that may be worth to share.