### PR TITLE
🪲 Fix flaky wait in customize adventure autosave test

### DIFF
--- a/tests/cypress/e2e/for-teacher_page/redesign/customize_adventure_autosave.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/redesign/customize_adventure_autosave.cy.js
@@ -18,7 +18,7 @@ function waitForUploadContaining(alias, marker, getValue, remainingAttempts = 6)
   });
 }
 
-function waitForSingleUpload(alias, assertions) {
+function waitForSingleUpload(alias, assertions = () => {}) {
   cy.wait(alias, { timeout: 20000 }).then(({ request, response }) => {
     expect(response?.statusCode).to.eq(200);
     assertions(request.body);
@@ -194,12 +194,12 @@ describe('Customize adventure redesign autosave', () => {
     cy.intercept('POST', '/for-teachers/customize-adventure').as('uploadAdventureDraft');
 
     cy.get('input[name="adventure_public"]').click({ force: true });
-    cy.wait('@uploadAdventureDraft');
+    waitForSingleUpload('@uploadAdventureDraft');
     cy.get('#public_adventure_options').should('be.visible');
     cy.get('#public_adventure_options').find('#languages_dropdown').should('exist');
 
     cy.get('input[name="adventure_public"]').click({ force: true });
-    cy.wait('@uploadAdventureDraft');
+    waitForSingleUpload('@uploadAdventureDraft');
     cy.get('#public_adventure_options').should('have.class', 'hidden');
   });
 
@@ -212,7 +212,7 @@ describe('Customize adventure redesign autosave', () => {
     cy.intercept('POST', '/for-teachers/customize-adventure').as('uploadAdventureDraft');
 
     cy.get('input[name="adventure_public"]').click({ force: true });
-    cy.wait('@uploadAdventureDraft');
+    waitForSingleUpload('@uploadAdventureDraft');
     cy.get('#public_adventure_options').should('be.visible');
 
     const tagName = uniqueName('adv-tag');


### PR DESCRIPTION
## Problem

`tests/cypress/e2e/for-teacher_page/redesign/customize_adventure_autosave.cy.js` fails intermittently on CI:

```
CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting
`5000ms` for the 2nd request to the route: `uploadAdventureDraft`.
No request ever occurred.
```

([example run](https://github.com/hedyorg/hedy/actions/runs/31284497463/job/93170907156))

## Cause

Three waits in this file were bare `cy.wait('@uploadAdventureDraft')`, which falls back to Cypress's **default 5000ms** timeout. Every other wait in the file goes through the `waitForSingleUpload` / `waitForUploadContaining` helpers, which deliberately use `{ timeout: 20000 }` because the autosave round-trip is slow under CI load.

Note the failure message says *5000ms*, not the file's 20s — the tell that these calls were missing the intended timeout.

It surfaced in `shows and hides public adventure options when public is toggled` because that test is the only one that waits for a **second** upload, after a save round-trip has already completed — the slowest point in the flow. The test immediately after it uses the same bare wait but only ever does the first toggle, which is why it kept passing.

## Fix

Route the three calls through the existing `waitForSingleUpload` helper so they inherit the 20s timeout and additionally assert a 200 response. Its `assertions` argument becomes optional, since these call sites only need to wait for the upload rather than inspect its body.

No production code changes — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)