### PR TITLE
🚚 Let the autoupdate workflow check out fork PRs again

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -52,12 +52,18 @@ jobs:
     # Make a distinction between Pull Request checkout and Push checkout. Push checkout
     # works mostly automatically, but for PRs we must be very explicit to get the right
     # branch and also support forks.
+    # actions/checkout@v6 refuses to check out fork code from a
+    # 'pull_request_target' workflow unless we opt in explicitly. Opting in is
+    # safe *for this job specifically*: it declares 'permissions: contents: read'
+    # and receives no secrets, which is exactly the mitigation GitHub recommends
+    # for running untrusted code. The privileged half lives in 'postupdate'.
     - uses: actions/checkout@v6
       name: Checkout branch
       with:
         fetch-depth: 1
         ref: ${{ steps.branch.outputs.branch }}
         repository: ${{ steps.branch.outputs.repo }}
+        allow-unsafe-pr-checkout: true
 
     #----------------------------------------------------------------------
     #  Actual build
@@ -123,12 +129,19 @@ jobs:
     steps:
 
     # Checkout source again
+    #
+    # NOTE: this job *does* hold a write token, so the same opt-in is a weightier
+    # decision here than in 'updatefiles'. It is acceptable because no fork code
+    # is executed in this job: we only check out the branch so that the commit
+    # lands on it, overlay the artifact, and commit. Keep it that way -- do not
+    # add build or test steps to this job.
     - uses: actions/checkout@v6
       name: Checkout branch
       with:
         fetch-depth: 1
         ref: ${{ needs.updatefiles.outputs.branch }}
         repository: ${{ needs.updatefiles.outputs.repo }}
+        allow-unsafe-pr-checkout: true
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -229,7 +229,7 @@ msgid "adventures_completed"
 msgstr "Adventures completed: {number_of_adventures}"
 
 msgid "adventures_info"
-msgstr "Each Hedy level has built-in exercises for students, which we call adventures. You can create your own adventures and add them to your classes. With your own adventures you can create adventures that are relevant and interesting for your students. You can find more information about creating your own adventures <a href=\"/for-teachers/manual">here</a>."
+msgstr "Each Hedy level has built-in exercises for students, which we call adventures. You can create your own adventures and add them to your classes. With your own adventures you can create adventures that are relevant and interesting for your students. You can find more information about creating your own adventures <a href=\"/for-teachers/manual\">here</a>."
 
 msgid "adventures_restored"
 msgstr "The default adventures have been restored."
@@ -397,7 +397,7 @@ msgid "classes"
 msgstr "Classes"
 
 msgid "classes_info"
-msgstr "Create a class to follow the progress of each student in dashboard, and to customize the adventures your students see, and even adding your own! You can create as many classes as you like, and each class can have multiple teachers each one with different roles. You can also add as many students as you want, but mind that each student can only be in one class at a time. You can find more information about classes in the <a href=\"/for-teachers/manual\">teacher manual</a>."
+msgstr "Create a class to follow the progress of each student in dashboard, and to customize the adventures your students see, and even adding your own! You can create as many classes as you like, and each class can have multiple teachers each one with different roles. You can also add as many students as you want, but mind that each student can only be in one class at a time. You can find more information about classes in the <a href=\"/for-teachers/manual">teacher manual</a>."
 
 msgid "clone"
 msgstr "Clone"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -229,7 +229,7 @@ msgid "adventures_completed"
 msgstr "Adventures completed: {number_of_adventures}"
 
 msgid "adventures_info"
-msgstr "Each Hedy level has built-in exercises for students, which we call adventures. You can create your own adventures and add them to your classes. With your own adventures you can create adventures that are relevant and interesting for your students. You can find more information about creating your own adventures <a href=\"/for-teachers/manual\">here</a>."
+msgstr "Each Hedy level has built-in exercises for students, which we call adventures. You can create your own adventures and add them to your classes. With your own adventures you can create adventures that are relevant and interesting for your students. You can find more information about creating your own adventures <a href=\"/for-teachers/manual">here</a>."
 
 msgid "adventures_restored"
 msgstr "The default adventures have been restored."

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -397,7 +397,7 @@ msgid "classes"
 msgstr "Classes"
 
 msgid "classes_info"
-msgstr "Create a class to follow the progress of each student in dashboard, and to customize the adventures your students see, and even adding your own! You can create as many classes as you like, and each class can have multiple teachers each one with different roles. You can also add as many students as you want, but mind that each student can only be in one class at a time. You can find more information about classes in the <a href=\"/for-teachers/manual">teacher manual</a>."
+msgstr "Create a class to follow the progress of each student in dashboard, and to customize the adventures your students see, and even adding your own! You can create as many classes as you like, and each class can have multiple teachers each one with different roles. You can also add as many students as you want, but mind that each student can only be in one class at a time. You can find more information about classes in the <a href=\"/for-teachers/manual\">teacher manual</a>."
 
 msgid "clone"
 msgstr "Clone"


### PR DESCRIPTION
## Problem

Every fork pull request has been failing the `updatefiles` check within a few seconds, before any code runs:

> Refusing to check out fork pull request code from a `pull_request_target` workflow.

`actions/checkout@v6` added a default refusal to check out fork code from `pull_request_target`, guarding against ["pwn request"](https://gh.io/securely-using-pull_request_target) attacks. v6 landed in this workflow on 2026-05-31 (#6579), and fork PRs have failed ever since — same-repo branches such as Dependabot's are unaffected, which is why this looked intermittent.

Because `postupdate` has `needs: [updatefiles]`, it is skipped too, so **the Weblate snippet tests (`doit run _autopr_weblate`) have not run on any translation PR since May.** Confirmed on #6643 (Weblate) and #6632 (an unrelated fork PR), which fail identically.

## Fix

Set `allow-unsafe-pr-checkout: true` on both checkout steps.

Opting in explicitly is preferred over pinning back to v5, because this workflow already implements exactly the mitigation the guard asks for. The job split is deliberate and predates this change:

- **`updatefiles`** runs the untrusted code, declares `permissions: contents: read`, and receives no secrets.
- **`postupdate`** holds the write token but executes no fork code — it only checks out the branch so the commit lands on it, overlays the uploaded artifact, and commits.

I added comments at both sites recording that reasoning, including a note on `postupdate` that build or test steps must not be added to it, since that is the property making the opt-in acceptable there.

## Scope

Only this workflow is affected. The other three `pull_request_target` workflows (`unlock-weblate.yml`, `codesee-arch-diagram.yml`, `autoapprove.yml`) have no checkout step.

## Note

This does not address GitHub's separate repository setting requiring approval before workflows run for outside contributors — that lives in Settings and cannot be fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)