### PR TITLE
💻 Drop the download button from the slides page

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -302,6 +302,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1322,6 +1328,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1629,6 +1638,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/templates/for-teachers/slides.html
+++ b/templates/for-teachers/slides.html
@@ -51,15 +51,6 @@
           <i class="fa-solid fa-expand"></i>
           <span>{{ _('present') }}</span>
         </a>
-        <button type="button"
-                class="white-btn-new inline-flex items-center gap-2"
-                id="download_slides_button"
-                data-cy="download_slides_button"
-                onclick="hedyApp.downloadSlides({{ selected_level }})">
-          <i class="fa-solid fa-download"></i>
-          <span>{{ _('download') }}</span>
-        </button>
-        <iframe class="hidden" id="level_{{ selected_level }}_slides" src="about:blank" aria-hidden="true" tabindex="-1"></iframe>
       </div>
     </div>
   </div>

--- a/tests/cypress/e2e/for-teacher_page/redesign/slides_behavior.cy.js
+++ b/tests/cypress/e2e/for-teacher_page/redesign/slides_behavior.cy.js
@@ -63,8 +63,13 @@ describe('Teacher slides behavior', () => {
 
   it('shows a whole slide at once, editor and output side by side', () => {
     cy.visit('/for-teachers/slides/6');
-    cy.getDataCy('slides_preview').should(($f) => {
-      expect($f[0].contentWindow.Reveal, 'deck is initialised').to.exist;
+    // The preview frame loads lazily, so it can still be booting when the page is
+    // ready: the Reveal global exists as soon as its own script runs, but the API
+    // we drive the deck with is only there once the deck has initialised.
+    cy.getDataCy('slides_preview', { timeout: 10000 }).should(($f) => {
+      const deck = $f[0].contentWindow.Reveal;
+      expect(deck, 'deck is initialised').to.exist;
+      expect(deck.isReady(), 'deck is ready').to.be.true;
     });
     cy.getDataCy('slides_preview').then(($f) => {
       const win = $f[0].contentWindow;

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -311,6 +311,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "الرجوع إلى الصف"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "صر راعيا وداعما"
 
@@ -1356,6 +1362,9 @@ msgstr "اللغة المفضلة للأوامر البرمجية"
 msgid "preferred_language"
 msgstr "اللغة المفضلة"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "معاينة"
 
@@ -1664,6 +1673,9 @@ msgstr "نائم..."
 
 msgid "slides"
 msgstr "شرائح"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "شرائح للمستوى"

--- a/translations/be/LC_MESSAGES/messages.po
+++ b/translations/be/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Стаць спонсарам"
 
@@ -1328,6 +1334,9 @@ msgstr "Прыярытэтная мова ключавых слоў"
 msgid "preferred_language"
 msgstr "Прыярытэтная мова"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Перадпрагляд"
 
@@ -1636,6 +1645,9 @@ msgstr "Спіць..."
 
 msgid "slides"
 msgstr "Слайды"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Слайды для ўзроўню"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -313,6 +313,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1333,6 +1339,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1640,6 +1649,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1343,6 +1349,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1650,6 +1659,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/brx/LC_MESSAGES/messages.po
+++ b/translations/brx/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ca/LC_MESSAGES/messages.po
+++ b/translations/ca/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Torna a la classe"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Fes-te patrocinador"
 
@@ -1357,6 +1363,9 @@ msgstr "Llengua per a les comandes"
 msgid "preferred_language"
 msgstr "Llengua per a mostrar"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Vista prèvia"
 
@@ -1665,6 +1674,9 @@ msgstr "Dormint..."
 
 msgid "slides"
 msgstr "Diapositives"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Diapositives pel nivell"

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -311,6 +311,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1349,6 +1355,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1657,6 +1666,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/cy/LC_MESSAGES/messages.po
+++ b/translations/cy/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/da/LC_MESSAGES/messages.po
+++ b/translations/da/LC_MESSAGES/messages.po
@@ -309,6 +309,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1331,6 +1337,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1638,6 +1647,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -321,6 +321,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Gehe zurück zur Klasse"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Werde ein Sponsor"
 
@@ -1373,6 +1379,9 @@ msgstr "Bevorzugte Schlüsselwortsprache"
 msgid "preferred_language"
 msgstr "Bevorzugte Sprache"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Vorschau"
 
@@ -1680,6 +1689,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -327,6 +327,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Επιστροφή στην τάξη"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1372,6 +1378,9 @@ msgstr "Προτιμώμενη γλώσσα για τα keywords"
 msgid "preferred_language"
 msgstr "Προτιμώμενη γλώσσα"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Προεπισκόπηση"
 
@@ -1682,6 +1691,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1676,7 +1676,7 @@ msgid "slides_for_level"
 msgstr "Slides for level"
 
 msgid "slides_info"
-msgstr "For each level of Hedy, we have created slides to help you teach. The slides contain explanations of each level, and Hedy examples that you can run inside the slides. Just click the link and get started! the Introduction slides are a general explanation of Hedy before level 1 The slides were created using <a href=\"https://slides.com\">slides.com</a>. If you want to adapt them yourself, you can download them, and then upload the resulting zip file to <a href=\"https://slides.com\">slides.com</a>. You can find more information about the slides in the <a href=\"https://hedy.org/for-teachers/manual/features\">teacher's manual</a>."
+msgstr "For each level of Hedy, we have created slides to help you teach. The slides contain explanations of each level, and Hedy examples that you can run inside the slides. Just click the link and get started! the Introduction slides are a general explanation of Hedy before level 1. You can find more information about the slides in the <a href=\"https://hedy.org/for-teachers/manual/features\">teacher's manual</a>."
 
 msgid "social_media"
 msgstr "Social media"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -314,6 +314,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Reen al klaso"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1354,6 +1360,9 @@ msgstr "Preferata lingvo de la ŝlosilvortoj"
 msgid "preferred_language"
 msgstr "Preferata lingvo"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Antaŭrigardi"
 
@@ -1661,6 +1670,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Volver a la clase"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Conviértete en patrocinador"
 
@@ -1357,6 +1363,9 @@ msgstr "Idioma preferido para las palabras clave"
 msgid "preferred_language"
 msgstr "Lenguaje favorito"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Previsualizar"
 
@@ -1665,6 +1674,9 @@ msgstr "Hibernando..."
 
 msgid "slides"
 msgstr "Diapositivas"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Diapositivas para el nivel"

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -309,6 +309,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1348,6 +1354,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1655,6 +1664,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1339,6 +1345,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1646,6 +1655,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/fi/LC_MESSAGES/messages.po
+++ b/translations/fi/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1328,6 +1334,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1635,6 +1644,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -331,6 +331,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Retourner à la classe"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Devenir un sponsor"
 
@@ -1387,6 +1393,9 @@ msgstr "Langue préférée pour les mots-clés"
 msgid "preferred_language"
 msgstr "Langue préferée"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Aperçu"
 
@@ -1694,6 +1703,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/fr_CA/LC_MESSAGES/messages.po
+++ b/translations/fr_CA/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1327,6 +1333,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1634,6 +1643,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -314,6 +314,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1347,6 +1353,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1656,6 +1665,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ga/LC_MESSAGES/messages.po
+++ b/translations/ga/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -323,6 +323,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "חזרה לכיתה"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1366,6 +1372,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1673,6 +1682,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -331,6 +331,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "कक्षा में वापस जाएं"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1381,6 +1387,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr "पसंदीदा भाषा"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "पूर्वावलोकन"
 
@@ -1691,6 +1700,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/hr/LC_MESSAGES/messages.po
+++ b/translations/hr/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1325,6 +1331,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1632,6 +1641,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -321,6 +321,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1384,6 +1390,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1696,6 +1705,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ia/LC_MESSAGES/messages.po
+++ b/translations/ia/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/iba/LC_MESSAGES/messages.po
+++ b/translations/iba/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -343,6 +343,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Kembali ke kelas"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Menjadi sponsor"
 
@@ -1397,6 +1403,9 @@ msgstr "Bahasa kata kunci pilihan"
 msgid "preferred_language"
 msgstr "Bahasa pilihan"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Pratinjau"
 
@@ -1704,6 +1713,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -315,6 +315,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1357,6 +1363,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1665,6 +1674,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -310,6 +310,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1348,6 +1354,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1655,6 +1664,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/jbo/LC_MESSAGES/messages.po
+++ b/translations/jbo/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/kab/LC_MESSAGES/messages.po
+++ b/translations/kab/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Ûɣal ɣer usmil"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Uɣal d amendad"
 
@@ -1332,6 +1338,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr "Tutlayt tufrint"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Taskant"
 
@@ -1640,6 +1649,9 @@ msgstr "Iḍes..."
 
 msgid "slides"
 msgstr "Tibursatin"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Tibursatin i uswir"

--- a/translations/kmr/LC_MESSAGES/messages.po
+++ b/translations/kmr/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/kn/LC_MESSAGES/messages.po
+++ b/translations/kn/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -341,6 +341,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "수업으로 돌아가기"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 #, fuzzy
 msgid "become_a_sponsor"
 msgstr "후원자 되기"
@@ -1544,6 +1550,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1874,6 +1883,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/lt/LC_MESSAGES/messages.po
+++ b/translations/lt/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/mi/LC_MESSAGES/messages.po
+++ b/translations/mi/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1328,6 +1334,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1635,6 +1644,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ml/LC_MESSAGES/messages.po
+++ b/translations/ml/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/mr/LC_MESSAGES/messages.po
+++ b/translations/mr/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ms/LC_MESSAGES/messages.po
+++ b/translations/ms/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/my/LC_MESSAGES/messages.po
+++ b/translations/my/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -327,6 +327,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Gå tilbake til klassen"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1375,6 +1381,9 @@ msgstr "Fortrukket språk for nøkkelord"
 msgid "preferred_language"
 msgstr "Foretrukket språk"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Forhåndsvis"
 
@@ -1683,6 +1692,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ne/LC_MESSAGES/messages.po
+++ b/translations/ne/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1325,6 +1331,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1632,6 +1641,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -343,6 +343,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Ga terug naar klas"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Word sponsor"
 
@@ -1398,6 +1404,9 @@ msgstr "Commando voorkeurstaal"
 msgid "preferred_language"
 msgstr "Voorkeurstaal"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Voorbeeld"
 
@@ -1708,6 +1717,9 @@ msgstr ""
 
 msgid "slides"
 msgstr "Dia's"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr ""

--- a/translations/pa_PK/LC_MESSAGES/messages.po
+++ b/translations/pa_PK/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/pap/LC_MESSAGES/messages.po
+++ b/translations/pap/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1327,6 +1333,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1634,6 +1643,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/peo/LC_MESSAGES/messages.po
+++ b/translations/peo/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Powróć do klasy"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Zostań sponsorem"
 
@@ -1361,6 +1367,9 @@ msgstr "Preferowany język słów kluczowych"
 msgid "preferred_language"
 msgstr "Preferowany język"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Podgląd"
 
@@ -1671,6 +1680,9 @@ msgstr "Śpi..."
 
 msgid "slides"
 msgstr "Slajdy"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Slajdy do poziomu"

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -325,6 +325,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Tornar-se um patrocinador"
 
@@ -1368,6 +1374,9 @@ msgstr "Idioma preferido de comandos"
 msgid "preferred_language"
 msgstr "Idioma preferido"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Prévia"
 
@@ -1675,6 +1684,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -312,6 +312,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1355,6 +1361,9 @@ msgstr "Idioma preferido de comandos"
 msgid "preferred_language"
 msgstr "Idioma preferido"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Prévia"
 
@@ -1662,6 +1671,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ro/LC_MESSAGES/messages.po
+++ b/translations/ro/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -328,6 +328,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Вернуться в класс"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Станьте спонсором"
 
@@ -1383,6 +1389,9 @@ msgstr "Предпочитаемый язык ключевых слов"
 msgid "preferred_language"
 msgstr "Предпочитаемый язык"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Предварительный просмотр"
 
@@ -1690,6 +1699,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/sl/LC_MESSAGES/messages.po
+++ b/translations/sl/LC_MESSAGES/messages.po
@@ -334,6 +334,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1372,6 +1378,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1679,6 +1688,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/so/LC_MESSAGES/messages.po
+++ b/translations/so/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/sq/LC_MESSAGES/messages.po
+++ b/translations/sq/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1326,6 +1332,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1633,6 +1642,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/sr/LC_MESSAGES/messages.po
+++ b/translations/sr/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Вратите се на час"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Постаните спонзор"
 
@@ -1358,6 +1364,9 @@ msgstr "Преферирани језик кључних речи"
 msgid "preferred_language"
 msgstr "Преферирани језик"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Преглед"
 
@@ -1666,6 +1675,9 @@ msgstr "Спавање..."
 
 msgid "slides"
 msgstr "Слајдови"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Слајдови за ниво"

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -331,6 +331,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Gå tillbaka till klassen"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Bli sponsor"
 
@@ -1387,6 +1393,9 @@ msgstr "Önskat språk för nyckelord"
 msgid "preferred_language"
 msgstr "Önskat språk"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Förhandsgranskning"
 
@@ -1694,6 +1703,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -310,6 +310,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1351,6 +1357,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1659,6 +1668,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/ta/LC_MESSAGES/messages.po
+++ b/translations/ta/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "மீண்டும் வகுப்புக்குச் செல்லுங்கள்"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "ஒரு ச்பான்சராகுங்கள்"
 
@@ -1357,6 +1363,9 @@ msgstr "விருப்பமான முக்கிய மொழி"
 msgid "preferred_language"
 msgstr "விருப்பமான மொழி"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "முன்னோட்டம்"
 
@@ -1665,6 +1674,9 @@ msgstr "தூக்கம் ..."
 
 msgid "slides"
 msgstr "ச்லைடுகள்"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "நிலைக்கு ச்லைடுகள்"

--- a/translations/te/LC_MESSAGES/messages.po
+++ b/translations/te/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1327,6 +1333,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1634,6 +1643,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/tl/LC_MESSAGES/messages.po
+++ b/translations/tl/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1330,6 +1336,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1638,6 +1647,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1343,6 +1349,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1650,6 +1659,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Sınıfına geri dön"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Sponsor olun"
 
@@ -1361,6 +1367,9 @@ msgstr "Tercih edilen anahtar kelime dili"
 msgid "preferred_language"
 msgstr "Tercih edilen dil"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Önizleme"
 
@@ -1668,6 +1677,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "Поверніться до класу"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "Стати спонсором"
 
@@ -1357,6 +1363,9 @@ msgstr "Бажана мова ключових слів"
 msgid "preferred_language"
 msgstr "Бажана мова"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "Переглянути"
 
@@ -1665,6 +1674,9 @@ msgstr "спить..."
 
 msgid "slides"
 msgstr "Слайди"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "Слайди для рівня"

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1328,6 +1334,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1635,6 +1644,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/uz/LC_MESSAGES/messages.po
+++ b/translations/uz/LC_MESSAGES/messages.po
@@ -305,6 +305,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1325,6 +1331,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1632,6 +1641,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/vi/LC_MESSAGES/messages.po
+++ b/translations/vi/LC_MESSAGES/messages.po
@@ -306,6 +306,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1328,6 +1334,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1635,6 +1644,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/yue_Hant/LC_MESSAGES/messages.po
+++ b/translations/yue_Hant/LC_MESSAGES/messages.po
@@ -304,6 +304,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1324,6 +1330,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1631,6 +1640,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr "回到课室"
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr "成为赞助商"
 
@@ -1359,6 +1365,9 @@ msgstr "首选关键字语言"
 msgid "preferred_language"
 msgstr "首选语言"
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr "预览"
 
@@ -1667,6 +1676,9 @@ msgstr "休眠..."
 
 msgid "slides"
 msgstr "幻灯"
+
+msgid "slides_card_info"
+msgstr ""
 
 msgid "slides_for_level"
 msgstr "级别幻灯"

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -307,6 +307,12 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
+msgid "background_information"
+msgstr ""
+
+msgid "background_information_info"
+msgstr ""
+
 msgid "become_a_sponsor"
 msgstr ""
 
@@ -1329,6 +1335,9 @@ msgstr ""
 msgid "preferred_language"
 msgstr ""
 
+msgid "present"
+msgstr ""
+
 msgid "preview"
 msgstr ""
 
@@ -1636,6 +1645,9 @@ msgid "sleeping"
 msgstr ""
 
 msgid "slides"
+msgstr ""
+
+msgid "slides_card_info"
 msgstr ""
 
 msgid "slides_for_level"


### PR DESCRIPTION
Removes the **Download** button from the slides page under Teaching materials, leaving **Present** as the only action. The download relied on scraping a hidden iframe of the deck, so that iframe is gone too. `hedyApp.downloadSlides` stays in `app.ts` for now, since the legacy top-level `templates/for-teachers.html` still references it.

The English `slides_info` paragraph also drops the sentence about downloading decks and re-uploading the zip to slides.com, plus both slides.com links. Other locales still carry their own translated version of that sentence and will need a Weblate pass.

**How to test**

* Go to `/for-teachers/teaching-materials` and open **Slides**.
* Pick any level: only the **Present** button shows under the preview, and it still opens `/slides/<level>` in a new tab.
* The intro paragraph no longer mentions downloading or slides.com; the teacher's manual link still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
