### PR TITLE
🚚 Fix the Weblate conflict-resolution workflow, which has been failing since the language extraction

### DIFF
--- a/tools/merge-weblate-resolving-conflicts.sh
+++ b/tools/merge-weblate-resolving-conflicts.sh
@@ -11,7 +11,6 @@ git checkout -B weblate-hedy-adventures-conflicts weblate-main/main
 
 # Normalize files in Weblate main repo
 doit run _autopr _autopr_weblate
-git add grammars
 git commit -am 'Normalize Weblate branch' --allow-empty
 
 # Merge from origin, preferring Weblate's changes


### PR DESCRIPTION
### Problem

The **Resolve Weblate conflicts** workflow has been failing at the same line since January. The most recent dispatch ([run 33021662164](https://github.com/hedyorg/hedy/actions/runs/33021662164/job/98353244228)) ends like this:

```
+ git add grammars
fatal: pathspec 'grammars' did not match any files
##[error]Process completed with exit code 128.
```

`grammars/` was removed from the repository root by #6475 ("Extract the Hedy language core to a separate directory"), and the generated grammars now live inside the `hedylang` package, ignored via `hedy/data/grammars-Total/*.lark`. `tools/merge-weblate-resolving-conflicts.sh` still tried to stage that directory.

Because the script runs under `set -eu`, this aborts the job with exit code 128 *before* the merge with `origin/main` ever happens, so "Switch back to main", "Create Pull Request" and the Weblate lock/reset steps are all skipped. Every dispatch spends about six and a half minutes on the `doit` build and then dies on the last line before the useful work starts.

### Fix

Delete the `git add grammars` line. The `git commit -am 'Normalize Weblate branch' --allow-empty` on the next line already stages every modified tracked file, which is what the normalization step actually produces, and there are no untracked generated files left for the `git add` to pick up.

I kept this deliberately narrow rather than switching to `git add -A`, because `_autopr_weblate` can write a `.tmp.md` report file that we would not want committed into the translation PR.

### Verification

The failure and its cause are confirmed from the run log; the script still passes `bash -n`. The workflow only runs on `workflow_dispatch`, so the real check is the next manual dispatch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)