### PR TITLE
🔓 Unlock Weblate automatically again when a translations PR closes

### DIFF
--- a/.github/workflows/unlock-weblate.yml
+++ b/.github/workflows/unlock-weblate.yml
@@ -5,17 +5,25 @@
 name: Unlock Weblate when PR is closed
 on:
   workflow_dispatch: { }
-#  Temporarily disabling automatic unlocking of Weblate until hedy levels are redesigned #6342
-#  pull_request_target:
-#    types:
-#      - closed
+  pull_request_target:
+    types:
+      - closed
 
 jobs:
   if_merged:
-    if:
+    # On 'pull_request_target' this runs for every closed PR, so only continue for the
+    # translation ones. On 'workflow_dispatch' there is no pull request in the event at
+    # all, and without the first clause the job would silently skip -- which is what made
+    # the manual escape hatch useless while the trigger above was disabled.
+    if: >
+        github.event_name == 'workflow_dispatch' ||
         github.event.pull_request.user.login == 'weblate' ||
         contains(github.event.pull_request.labels.*.name, 'translations')
     runs-on: ubuntu-latest
+    # This job only talks to the Weblate API; it never touches the repository, so it
+    # needs nothing from GITHUB_TOKEN. That matters because 'pull_request_target' runs
+    # in the context of the base repository, with access to our secrets.
+    permissions: {}
     steps:
     # These are all the same as in 'update-weblate.yml'
     - name: Set up Python 3.12


### PR DESCRIPTION
Follow-up to #6654 and #6656. Now that the Weblate conflict workflow runs end to end again ([run 33031565036](https://github.com/hedyorg/hedy/actions/runs/33031565036)), it locked six components and opened #6657 — and nothing will unlock them, because this workflow's trigger has been switched off for over a year.

### Two separate problems

**1. The automatic trigger is commented out.**

```yaml
#  Temporarily disabling automatic unlocking of Weblate until hedy levels are redesigned #6342
#  pull_request_target:
#    types:
#      - closed
```

#6342 asked to keep Weblate locked for "around a month" while the levels were rearranged. It closed on 2025-05-20. The trigger was never restored, so the lock loops in `update-weblate.yml` and `resolve-weblate-conflict.yml` have had no counterpart since — both lock, neither unlocks, and clearing it has been a manual job in the Weblate UI.

**2. The manual fallback never worked either.**

The job condition only looked at the pull request in the event payload:

```yaml
    if:
        github.event.pull_request.user.login == 'weblate' ||
        contains(github.event.pull_request.labels.*.name, 'translations')
```

On `workflow_dispatch` there is no pull request in the event, so both clauses are false and the job silently skips. This workflow has **zero recorded runs** in its history, which fits: the only enabled trigger could never get past this condition. So while the automatic trigger was off, there was no working escape hatch at all.

This PR restores the trigger and accepts `workflow_dispatch` explicitly, so both paths work.

### Also: no repository permissions

`pull_request_target` runs in the base repository's context with access to our secrets, which is why it deserves care. This job never checks out a branch and never touches the repository — it installs `wlc`, writes a `.weblate` config from `WEBLATE_API_KEY`, and calls the Weblate API. So it is pinned to `permissions: {}`.

### Deliberately unchanged

The component list stays `glossary adventures keywords client-messages web-texts webpages`, exactly mirroring the two lock loops. The project also has `slides` and `workbooks` now, but neither is locked by our workflows — `workbooks` is currently locked by hand — and unlocking components we never locked would override somebody's deliberate choice.

### After merging

This does not clear the current lock, since #6657 was already open before the trigger came back. Either close or merge #6657 once this is in and the trigger will fire, or dispatch this workflow manually — which will actually work now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)